### PR TITLE
Use homedir for SSH key and add IdentitiesOnly

### DIFF
--- a/electron/azure-vm-backend.ts
+++ b/electron/azure-vm-backend.ts
@@ -14,6 +14,7 @@
 //   Password – pass sshPassword; requires sshpass(1) to be on PATH.
 
 import { spawn, type ChildProcess, type SpawnOptions } from 'node:child_process';
+import os from 'node:os';
 import type {
   IRemoteBackend,
   RemoteConnectOptions,
@@ -59,7 +60,8 @@ function buildSshArgs(
     '-p', String(session.sshPort),
   ];
   if (session.sshKeyPath?.trim()) {
-    args.push('-i', session.sshKeyPath.trim());
+    const keyPath = session.sshKeyPath.trim().replace(/^~(?=$|\/)/, os.homedir());
+    args.push('-o', 'IdentitiesOnly=yes', '-i', keyPath);
   }
   args.push(`${session.username}@${session.host}`);
   return args;

--- a/electron/remote-file-backend.ts
+++ b/electron/remote-file-backend.ts
@@ -61,7 +61,8 @@ function buildSshBaseArgs(session: RemoteFileSession): string[] {
     '-p', String(session.port),
   ];
   if (session.sshKeyPath?.trim()) {
-    args.push('-i', session.sshKeyPath.trim());
+    const keyPath = session.sshKeyPath.trim().replace(/^~(?=$|\/)/, os.homedir());
+    args.push('-o', 'IdentitiesOnly=yes', '-i', keyPath);
   }
   args.push(`${session.username}@${session.host}`);
   return args;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "starmade-launcher",
   "private": true,
-  "version": "4.1.6",
+  "version": "4.1.7",
   "description": "StarMade Launcher",
   "author": "Schine GmbH & StarMade Contributors",
   "type": "module",


### PR DESCRIPTION
Expand SSH key paths that start with ~ to the user's home directory and add '-o IdentitiesOnly=yes' when passing a key to ssh. Imported node:os and updated buildSshArgs (electron/azure-vm-backend.ts) and buildSshBaseArgs (electron/remote-file-backend.ts) to replace leading ~ with os.homedir() and include the IdentitiesOnly option to ensure the specified key is used. Also bumped package.json version to 4.1.7.