### PR TITLE
Add Blueprint Catalog UI and backend with Templates support

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -5,6 +5,7 @@ import News from './components/pages/News';
 import Screenshots from './components/pages/Screenshots';
 import Mods from './components/pages/Mods';
 import Blueprints from './components/pages/Blueprints';
+import Templates from './components/pages/Templates';
 import Installations from './components/pages/Installations';
 import Play from './components/pages/Play';
 import Settings from './components/pages/Settings';
@@ -347,8 +348,10 @@ const App: React.FC = () => {
         return <Screenshots />;
       case 'Mods':
         return <Mods />;
-      case 'Catalog':
+      case 'Blueprints':
         return <Blueprints />;
+      case 'Templates':
+        return <Templates />;
       case 'Settings': {
         const settingsProps = 'initialSection' in pageProps ? pageProps : {};
         return <Settings {...settingsProps} />;

--- a/App.tsx
+++ b/App.tsx
@@ -347,7 +347,7 @@ const App: React.FC = () => {
         return <Screenshots />;
       case 'Mods':
         return <Mods />;
-      case 'Blueprints':
+      case 'Catalog':
         return <Blueprints />;
       case 'Settings': {
         const settingsProps = 'initialSection' in pageProps ? pageProps : {};

--- a/App.tsx
+++ b/App.tsx
@@ -346,12 +346,12 @@ const App: React.FC = () => {
         return <News />;
       case 'Screenshots':
         return <Screenshots />;
-      case 'Mods':
-        return <Mods />;
       case 'Blueprints':
         return <Blueprints />;
       case 'Templates':
         return <Templates />;
+      case 'Mods':
+        return <Mods />;
       case 'Settings': {
         const settingsProps = 'initialSection' in pageProps ? pageProps : {};
         return <Settings {...settingsProps} />;

--- a/App.tsx
+++ b/App.tsx
@@ -4,6 +4,7 @@ import Footer from './components/layout/Footer';
 import News from './components/pages/News';
 import Screenshots from './components/pages/Screenshots';
 import Mods from './components/pages/Mods';
+import Blueprints from './components/pages/Blueprints';
 import Installations from './components/pages/Installations';
 import Play from './components/pages/Play';
 import Settings from './components/pages/Settings';
@@ -346,6 +347,8 @@ const App: React.FC = () => {
         return <Screenshots />;
       case 'Mods':
         return <Mods />;
+      case 'Blueprints':
+        return <Blueprints />;
       case 'Settings': {
         const settingsProps = 'initialSection' in pageProps ? pageProps : {};
         return <Settings {...settingsProps} />;

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -229,7 +229,7 @@ const WindowControls: React.FC = () => {
 
 const Navigation: React.FC = () => {
     const { activePage, navigate } = useApp();
-    const navItems: Page[] = ['Play', 'Installations', 'News', 'Screenshots', 'Mods', 'Blueprints', 'Templates'];
+    const navItems: Page[] = ['Play', 'Installations', 'News', 'Screenshots', 'Blueprints', 'Templates', 'Mods'];
 
     return (
         <nav className="flex items-center gap-10">

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -229,7 +229,7 @@ const WindowControls: React.FC = () => {
 
 const Navigation: React.FC = () => {
     const { activePage, navigate } = useApp();
-    const navItems: Page[] = ['Play', 'Installations', 'News', 'Screenshots', 'Mods', 'Blueprints'];
+    const navItems: Page[] = ['Play', 'Installations', 'News', 'Screenshots', 'Mods', 'Catalog'];
 
     return (
         <nav className="flex items-center gap-10">

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -229,7 +229,7 @@ const WindowControls: React.FC = () => {
 
 const Navigation: React.FC = () => {
     const { activePage, navigate } = useApp();
-    const navItems: Page[] = ['Play', 'Installations', 'News', 'Screenshots', 'Mods', 'Catalog'];
+    const navItems: Page[] = ['Play', 'Installations', 'News', 'Screenshots', 'Mods', 'Blueprints', 'Templates'];
 
     return (
         <nav className="flex items-center gap-10">

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -229,7 +229,7 @@ const WindowControls: React.FC = () => {
 
 const Navigation: React.FC = () => {
     const { activePage, navigate } = useApp();
-    const navItems: Page[] = ['Play', 'Installations', 'News', 'Screenshots', 'Mods'];
+    const navItems: Page[] = ['Play', 'Installations', 'News', 'Screenshots', 'Mods', 'Blueprints'];
 
     return (
         <nav className="flex items-center gap-10">

--- a/components/pages/Blueprints/index.tsx
+++ b/components/pages/Blueprints/index.tsx
@@ -1,0 +1,605 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import PageContainer from '../../common/PageContainer';
+import CustomDropdown from '../../common/CustomDropdown';
+import { useData } from '../../../contexts/DataContext';
+import { FolderIcon, TrashIcon, DownloadIcon, ArchiveIcon } from '../../common/icons';
+import type { ManagedItem } from '../../../types';
+
+// ─── Types mirroring the preload API return shapes ──────────────────────────
+
+interface BlueprintMeta {
+  name: string;
+  type: string;
+  classification?: string;
+  boundingBox?: { min: [number, number, number]; max: [number, number, number] };
+  elementCount?: number;
+  sizeBytes: number;
+  modifiedMs: number;
+  dockedCount: number;
+}
+
+interface ExportedMeta {
+  fileName: string;
+  sizeBytes: number;
+  modifiedMs: number;
+}
+
+interface TemplateMeta {
+  fileName: string;
+  sizeBytes: number;
+  modifiedMs: number;
+}
+
+interface CatalogListing {
+  catalogPath: string;
+  blueprints: BlueprintMeta[];
+  exported: ExportedMeta[];
+  templates: TemplateMeta[];
+  error?: string;
+}
+
+type CatalogItemRef =
+  | { kind: 'blueprint'; name: string }
+  | { kind: 'exported'; fileName: string }
+  | { kind: 'template'; fileName: string };
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+const formatBytes = (value: number): string => {
+  if (value < 1024) return `${value} B`;
+  const kb = value / 1024;
+  if (kb < 1024) return `${kb.toFixed(1)} KB`;
+  return `${(kb / 1024).toFixed(2)} MB`;
+};
+
+const TYPE_COLORS: Record<string, string> = {
+  SHIP: 'bg-blue-500/20 text-blue-300 border-blue-500/30',
+  SPACE_STATION: 'bg-purple-500/20 text-purple-300 border-purple-500/30',
+  SHOP: 'bg-yellow-500/20 text-yellow-300 border-yellow-500/30',
+  ASTEROID: 'bg-gray-500/20 text-gray-300 border-gray-500/30',
+  MANAGED_ASTEROID: 'bg-gray-500/20 text-gray-300 border-gray-500/30',
+  PLANET: 'bg-green-500/20 text-green-300 border-green-500/30',
+  UNKNOWN: 'bg-slate-500/20 text-slate-300 border-slate-500/30',
+};
+
+const typeLabel = (t: string) => t.replace(/_/g, ' ');
+
+// ─── Component ──────────────────────────────────────────────────────────────
+
+const Blueprints: React.FC = () => {
+  const { installations, selectedInstallationId } = useData();
+
+  // ── State ─────────────────────────────────────────────────────────────────
+  const [selectedInstanceId, setSelectedInstanceId] = useState<string | null>(selectedInstallationId);
+  const [catalogData, setCatalogData] = useState<CatalogListing | null>(null);
+  const [installData, setInstallData] = useState<CatalogListing | null>(null);
+  const [isLoadingCatalog, setIsLoadingCatalog] = useState(false);
+  const [isLoadingInstall, setIsLoadingInstall] = useState(false);
+  const [catalogSelection, setCatalogSelection] = useState<Set<string>>(new Set());
+  const [installSelection, setInstallSelection] = useState<Set<string>>(new Set());
+  const [overwrite, setOverwrite] = useState(false);
+  const [status, setStatus] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isBusy, setIsBusy] = useState(false);
+
+  const launcher = window.launcher;
+
+  // ── Instances ─────────────────────────────────────────────────────────────
+  const instances = useMemo(() => {
+    const deduped = new Map<string, ManagedItem>();
+    installations
+      .filter((item) => item.path?.trim().length > 0)
+      .forEach((item) => deduped.set(item.id, item));
+    return Array.from(deduped.values());
+  }, [installations]);
+
+  useEffect(() => {
+    if (selectedInstanceId && instances.some((i) => i.id === selectedInstanceId)) return;
+    setSelectedInstanceId(instances[0]?.id ?? null);
+  }, [instances, selectedInstanceId]);
+
+  const selectedInstance = useMemo(
+    () => instances.find((i) => i.id === selectedInstanceId) ?? null,
+    [instances, selectedInstanceId],
+  );
+
+  // ── Data loading ──────────────────────────────────────────────────────────
+
+  const loadCatalog = useCallback(async () => {
+    if (!launcher?.catalog?.list) return;
+    setIsLoadingCatalog(true);
+    try {
+      const data = await launcher.catalog.list();
+      setCatalogData(data);
+      if (data.error) setError(data.error);
+    } catch (err) {
+      setError(`Failed to load catalog: ${String(err)}`);
+    } finally {
+      setIsLoadingCatalog(false);
+    }
+  }, [launcher]);
+
+  const loadInstall = useCallback(async () => {
+    if (!launcher?.catalog?.listInstallation || !selectedInstance?.path) {
+      setInstallData(null);
+      return;
+    }
+    setIsLoadingInstall(true);
+    try {
+      const data = await launcher.catalog.listInstallation(selectedInstance.path);
+      setInstallData(data);
+    } catch (err) {
+      setError(`Failed to load installation blueprints: ${String(err)}`);
+    } finally {
+      setIsLoadingInstall(false);
+    }
+  }, [launcher, selectedInstance]);
+
+  useEffect(() => { void loadCatalog(); }, [loadCatalog]);
+  useEffect(() => { void loadInstall(); }, [loadInstall]);
+
+  // ── Selection helpers ─────────────────────────────────────────────────────
+
+  const toggleCatalogItem = (key: string) => {
+    setCatalogSelection((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key); else next.add(key);
+      return next;
+    });
+  };
+
+  const toggleInstallItem = (key: string) => {
+    setInstallSelection((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key); else next.add(key);
+      return next;
+    });
+  };
+
+  const catalogItemRefFromKey = (key: string): CatalogItemRef => {
+    if (key.startsWith('bp:')) return { kind: 'blueprint', name: key.slice(3) };
+    if (key.startsWith('exp:')) return { kind: 'exported', fileName: key.slice(4) };
+    return { kind: 'template', fileName: key.slice(4) };
+  };
+
+  // ── Actions ───────────────────────────────────────────────────────────────
+
+  const handleDeploy = async () => {
+    if (!selectedInstance || catalogSelection.size === 0) return;
+    setIsBusy(true);
+    setStatus(null);
+    setError(null);
+    try {
+      const items = Array.from(catalogSelection).map(catalogItemRefFromKey);
+      const result = await launcher.catalog.deploy(items, [selectedInstance.path], overwrite);
+      if (result.success) {
+        setStatus(`Deployed ${result.copiedCount ?? 0} item(s)${result.skippedCount ? `, skipped ${result.skippedCount}` : ''}`);
+      } else {
+        setError(result.errors?.join('; ') ?? 'Deploy failed');
+      }
+      setCatalogSelection(new Set());
+      void loadInstall();
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setIsBusy(false);
+    }
+  };
+
+  const handleImport = async () => {
+    if (!selectedInstance || installSelection.size === 0) return;
+    setIsBusy(true);
+    setStatus(null);
+    setError(null);
+    try {
+      const items = Array.from(installSelection).map(catalogItemRefFromKey);
+      const result = await launcher.catalog.import(selectedInstance.path, items, overwrite);
+      if (result.success) {
+        setStatus(`Imported ${result.copiedCount ?? 0} item(s)${result.skippedCount ? `, skipped ${result.skippedCount}` : ''}`);
+      } else {
+        setError(result.errors?.join('; ') ?? 'Import failed');
+      }
+      setInstallSelection(new Set());
+      void loadCatalog();
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setIsBusy(false);
+    }
+  };
+
+  const handleDeleteSelected = async () => {
+    if (catalogSelection.size === 0) return;
+    setIsBusy(true);
+    setStatus(null);
+    setError(null);
+    let deleted = 0;
+    const errs: string[] = [];
+    for (const key of catalogSelection) {
+      const item = catalogItemRefFromKey(key);
+      try {
+        const r = await launcher.catalog.delete(item);
+        if (r.success) deleted++;
+        else if (r.error) errs.push(r.error);
+      } catch (err) {
+        errs.push(String(err));
+      }
+    }
+    if (errs.length) setError(errs.join('; '));
+    else setStatus(`Deleted ${deleted} item(s) from catalog`);
+    setCatalogSelection(new Set());
+    void loadCatalog();
+    setIsBusy(false);
+  };
+
+  const handleImportSment = async () => {
+    const selected = await launcher.dialog.openFile(undefined, undefined as unknown as 'image');
+    if (!selected || !selected.endsWith('.sment')) {
+      if (selected) setError('Please select a .sment file');
+      return;
+    }
+    setIsBusy(true);
+    setStatus(null);
+    setError(null);
+    try {
+      const result = await launcher.catalog.importSment(selected);
+      if (result.success) {
+        setStatus(`Imported .sment file (${result.copiedCount ?? 0} item(s))`);
+      } else {
+        setError(result.errors?.join('; ') ?? 'Import failed');
+      }
+      void loadCatalog();
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setIsBusy(false);
+    }
+  };
+
+  const handleSetupCatalog = async () => {
+    const selected = await launcher.dialog.openFolder();
+    if (selected) {
+      await launcher.store.set('catalogPath', selected);
+      void loadCatalog();
+    }
+  };
+
+  // ── No catalog path configured ────────────────────────────────────────────
+
+  const noCatalog = !catalogData?.catalogPath;
+
+  // ── Render ────────────────────────────────────────────────────────────────
+
+  return (
+    <PageContainer closeTarget="Play" resizable>
+      <div className="flex flex-col h-full min-h-0">
+        {/* ── Header ───────────────────────────────────────────────────────── */}
+        <div className="flex items-center justify-between mb-4 flex-shrink-0">
+          <h1 className="font-display text-3xl font-bold uppercase text-white tracking-wider">Blueprints</h1>
+          <div className="flex items-center gap-3">
+            {/* Installation selector */}
+            {instances.length > 0 && (
+              <CustomDropdown
+                options={instances.map((i) => ({ value: i.id, label: i.name || i.id }))}
+                value={selectedInstanceId ?? ''}
+                onChange={(id) => { setSelectedInstanceId(id); setInstallSelection(new Set()); }}
+                className="w-60"
+              />
+            )}
+          </div>
+        </div>
+
+        {/* ── Status / error bar ───────────────────────────────────────────── */}
+        {(status || error) && (
+          <div className={`mb-3 px-4 py-2 rounded-lg text-sm flex-shrink-0 ${error ? 'bg-red-500/20 border border-red-500/30 text-red-300' : 'bg-green-500/20 border border-green-500/30 text-green-300'}`}>
+            {error ?? status}
+            <button onClick={() => { setStatus(null); setError(null); }} className="ml-2 opacity-60 hover:opacity-100">&times;</button>
+          </div>
+        )}
+
+        {/* ── No catalog setup ─────────────────────────────────────────────── */}
+        {noCatalog && (
+          <div className="flex-1 flex items-center justify-center">
+            <div className="text-center space-y-4">
+              <p className="text-gray-400 text-lg">No blueprint catalog directory configured.</p>
+              <p className="text-gray-500 text-sm">Choose a directory to store your centralized blueprint and template collection.</p>
+              <button
+                onClick={handleSetupCatalog}
+                className="px-6 py-3 rounded-lg bg-starmade-accent hover:bg-starmade-accent/80 transition-colors font-semibold uppercase tracking-wider"
+              >
+                Choose Catalog Folder
+              </button>
+            </div>
+          </div>
+        )}
+
+        {/* ── Main two-panel layout ────────────────────────────────────────── */}
+        {!noCatalog && (
+          <div className="flex-1 flex gap-4 min-h-0">
+            {/* ── Left: Catalog ──────────────────────────────────────────── */}
+            <div className="flex-1 flex flex-col min-h-0 min-w-0">
+              <div className="flex items-center justify-between mb-2">
+                <h2 className="font-display text-sm font-bold uppercase tracking-wider text-starmade-text-accent">Catalog</h2>
+                <div className="flex items-center gap-2">
+                  <button
+                    onClick={handleImportSment}
+                    disabled={isBusy}
+                    className="p-1.5 rounded-md hover:bg-white/10 transition-colors text-gray-400 hover:text-white disabled:opacity-40"
+                    title="Import .sment file"
+                  >
+                    <ArchiveIcon className="w-4 h-4" />
+                  </button>
+                  {catalogData?.catalogPath && (
+                    <button
+                      onClick={() => launcher.shell.openPath(catalogData.catalogPath)}
+                      className="p-1.5 rounded-md hover:bg-white/10 transition-colors text-gray-400 hover:text-white"
+                      title="Open catalog folder"
+                    >
+                      <FolderIcon className="w-4 h-4" />
+                    </button>
+                  )}
+                  <button
+                    onClick={handleDeleteSelected}
+                    disabled={isBusy || catalogSelection.size === 0}
+                    className="p-1.5 rounded-md hover:bg-red-500/20 transition-colors text-gray-400 hover:text-red-400 disabled:opacity-40"
+                    title="Delete selected from catalog"
+                  >
+                    <TrashIcon className="w-4 h-4" />
+                  </button>
+                  <button
+                    onClick={() => void loadCatalog()}
+                    disabled={isLoadingCatalog}
+                    className="px-2 py-1 text-xs rounded bg-white/5 hover:bg-white/10 transition-colors text-gray-400"
+                  >
+                    {isLoadingCatalog ? 'Loading...' : 'Refresh'}
+                  </button>
+                </div>
+              </div>
+              <div className="flex-1 overflow-y-auto space-y-1 pr-1">
+                {isLoadingCatalog && <p className="text-gray-500 text-sm p-4 text-center">Loading catalog...</p>}
+                {!isLoadingCatalog && catalogData && catalogData.blueprints.length === 0 && catalogData.exported.length === 0 && catalogData.templates.length === 0 && (
+                  <p className="text-gray-500 text-sm p-4 text-center">Catalog is empty. Import blueprints from an installation or a .sment file.</p>
+                )}
+                {/* Blueprints */}
+                {catalogData?.blueprints.map((bp) => {
+                  const key = `bp:${bp.name}`;
+                  return (
+                    <BlueprintRow
+                      key={key}
+                      name={bp.name}
+                      type={bp.type}
+                      classification={bp.classification}
+                      elementCount={bp.elementCount}
+                      sizeBytes={bp.sizeBytes}
+                      dockedCount={bp.dockedCount}
+                      selected={catalogSelection.has(key)}
+                      onToggle={() => toggleCatalogItem(key)}
+                    />
+                  );
+                })}
+                {/* Exported */}
+                {catalogData && catalogData.exported.length > 0 && (
+                  <div className="pt-2">
+                    <p className="text-xs text-gray-500 uppercase tracking-wider mb-1 px-2">Exported (.sment)</p>
+                    {catalogData.exported.map((exp) => {
+                      const key = `exp:${exp.fileName}`;
+                      return (
+                        <FileRow
+                          key={key}
+                          fileName={exp.fileName}
+                          sizeBytes={exp.sizeBytes}
+                          selected={catalogSelection.has(key)}
+                          onToggle={() => toggleCatalogItem(key)}
+                        />
+                      );
+                    })}
+                  </div>
+                )}
+                {/* Templates */}
+                {catalogData && catalogData.templates.length > 0 && (
+                  <div className="pt-2">
+                    <p className="text-xs text-gray-500 uppercase tracking-wider mb-1 px-2">Templates (.smtpl)</p>
+                    {catalogData.templates.map((tpl) => {
+                      const key = `tpl:${tpl.fileName}`;
+                      return (
+                        <FileRow
+                          key={key}
+                          fileName={tpl.fileName}
+                          sizeBytes={tpl.sizeBytes}
+                          selected={catalogSelection.has(key)}
+                          onToggle={() => toggleCatalogItem(key)}
+                        />
+                      );
+                    })}
+                  </div>
+                )}
+              </div>
+            </div>
+
+            {/* ── Center: Action buttons ─────────────────────────────────── */}
+            <div className="flex flex-col items-center justify-center gap-3 flex-shrink-0 px-1">
+              <button
+                onClick={handleDeploy}
+                disabled={isBusy || catalogSelection.size === 0 || !selectedInstance}
+                className="px-3 py-2 rounded-lg bg-starmade-accent/80 hover:bg-starmade-accent disabled:opacity-30 disabled:cursor-not-allowed transition-colors text-sm font-semibold uppercase tracking-wider whitespace-nowrap"
+                title="Deploy selected catalog items to installation"
+              >
+                Deploy &rarr;
+              </button>
+              <button
+                onClick={handleImport}
+                disabled={isBusy || installSelection.size === 0 || !selectedInstance}
+                className="px-3 py-2 rounded-lg bg-starmade-accent/80 hover:bg-starmade-accent disabled:opacity-30 disabled:cursor-not-allowed transition-colors text-sm font-semibold uppercase tracking-wider whitespace-nowrap"
+                title="Import selected installation items to catalog"
+              >
+                &larr; Import
+              </button>
+              <label className="flex items-center gap-1.5 text-xs text-gray-400 cursor-pointer mt-2">
+                <input
+                  type="checkbox"
+                  checked={overwrite}
+                  onChange={(e) => setOverwrite(e.target.checked)}
+                  className="rounded border-gray-600 bg-gray-800 text-starmade-accent focus:ring-starmade-accent/50"
+                />
+                Overwrite
+              </label>
+            </div>
+
+            {/* ── Right: Installation ────────────────────────────────────── */}
+            <div className="flex-1 flex flex-col min-h-0 min-w-0">
+              <div className="flex items-center justify-between mb-2">
+                <h2 className="font-display text-sm font-bold uppercase tracking-wider text-starmade-text-accent">
+                  Installation{selectedInstance ? `: ${selectedInstance.name}` : ''}
+                </h2>
+                <button
+                  onClick={() => void loadInstall()}
+                  disabled={isLoadingInstall}
+                  className="px-2 py-1 text-xs rounded bg-white/5 hover:bg-white/10 transition-colors text-gray-400"
+                >
+                  {isLoadingInstall ? 'Loading...' : 'Refresh'}
+                </button>
+              </div>
+              <div className="flex-1 overflow-y-auto space-y-1 pr-1">
+                {!selectedInstance && <p className="text-gray-500 text-sm p-4 text-center">No installation selected.</p>}
+                {selectedInstance && isLoadingInstall && <p className="text-gray-500 text-sm p-4 text-center">Loading...</p>}
+                {selectedInstance && !isLoadingInstall && installData && installData.blueprints.length === 0 && installData.exported.length === 0 && installData.templates.length === 0 && (
+                  <p className="text-gray-500 text-sm p-4 text-center">No blueprints or templates in this installation.</p>
+                )}
+                {/* Blueprints */}
+                {installData?.blueprints.map((bp) => {
+                  const key = `bp:${bp.name}`;
+                  return (
+                    <BlueprintRow
+                      key={key}
+                      name={bp.name}
+                      type={bp.type}
+                      classification={bp.classification}
+                      elementCount={bp.elementCount}
+                      sizeBytes={bp.sizeBytes}
+                      dockedCount={bp.dockedCount}
+                      selected={installSelection.has(key)}
+                      onToggle={() => toggleInstallItem(key)}
+                    />
+                  );
+                })}
+                {/* Exported */}
+                {installData && installData.exported.length > 0 && (
+                  <div className="pt-2">
+                    <p className="text-xs text-gray-500 uppercase tracking-wider mb-1 px-2">Exported (.sment)</p>
+                    {installData.exported.map((exp) => {
+                      const key = `exp:${exp.fileName}`;
+                      return (
+                        <FileRow
+                          key={key}
+                          fileName={exp.fileName}
+                          sizeBytes={exp.sizeBytes}
+                          selected={installSelection.has(key)}
+                          onToggle={() => toggleInstallItem(key)}
+                        />
+                      );
+                    })}
+                  </div>
+                )}
+                {/* Templates */}
+                {installData && installData.templates.length > 0 && (
+                  <div className="pt-2">
+                    <p className="text-xs text-gray-500 uppercase tracking-wider mb-1 px-2">Templates (.smtpl)</p>
+                    {installData.templates.map((tpl) => {
+                      const key = `tpl:${tpl.fileName}`;
+                      return (
+                        <FileRow
+                          key={key}
+                          fileName={tpl.fileName}
+                          sizeBytes={tpl.sizeBytes}
+                          selected={installSelection.has(key)}
+                          onToggle={() => toggleInstallItem(key)}
+                        />
+                      );
+                    })}
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    </PageContainer>
+  );
+};
+
+// ─── Row sub-components ─────────────────────────────────────────────────────
+
+const BlueprintRow: React.FC<{
+  name: string;
+  type: string;
+  classification?: string;
+  elementCount?: number;
+  sizeBytes: number;
+  dockedCount: number;
+  selected: boolean;
+  onToggle: () => void;
+}> = ({ name, type, classification, elementCount, sizeBytes, dockedCount, selected, onToggle }) => {
+  const colors = TYPE_COLORS[type] ?? TYPE_COLORS.UNKNOWN;
+  return (
+    <button
+      onClick={onToggle}
+      className={`w-full text-left px-3 py-2 rounded-lg border transition-colors flex items-center gap-3 ${
+        selected
+          ? 'bg-starmade-accent/15 border-starmade-accent/40'
+          : 'bg-black/20 border-white/5 hover:bg-white/5'
+      }`}
+    >
+      <input
+        type="checkbox"
+        checked={selected}
+        onChange={onToggle}
+        onClick={(e) => e.stopPropagation()}
+        className="rounded border-gray-600 bg-gray-800 text-starmade-accent focus:ring-starmade-accent/50 flex-shrink-0"
+      />
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2">
+          <span className="text-sm font-medium text-white truncate">{name}</span>
+          <span className={`text-[10px] font-bold uppercase tracking-wider px-1.5 py-0.5 rounded border ${colors}`}>
+            {typeLabel(type)}
+          </span>
+          {classification && (
+            <span className="text-[10px] uppercase tracking-wider text-gray-400">{classification.replace(/_/g, ' ')}</span>
+          )}
+        </div>
+        <div className="flex items-center gap-3 mt-0.5 text-xs text-gray-500">
+          <span>{formatBytes(sizeBytes)}</span>
+          {elementCount != null && <span>{elementCount.toLocaleString()} blocks</span>}
+          {dockedCount > 0 && <span>{dockedCount} docked</span>}
+        </div>
+      </div>
+    </button>
+  );
+};
+
+const FileRow: React.FC<{
+  fileName: string;
+  sizeBytes: number;
+  selected: boolean;
+  onToggle: () => void;
+}> = ({ fileName, sizeBytes, selected, onToggle }) => (
+  <button
+    onClick={onToggle}
+    className={`w-full text-left px-3 py-1.5 rounded-lg border transition-colors flex items-center gap-3 ${
+      selected
+        ? 'bg-starmade-accent/15 border-starmade-accent/40'
+        : 'bg-black/20 border-white/5 hover:bg-white/5'
+    }`}
+  >
+    <input
+      type="checkbox"
+      checked={selected}
+      onChange={onToggle}
+      onClick={(e) => e.stopPropagation()}
+      className="rounded border-gray-600 bg-gray-800 text-starmade-accent focus:ring-starmade-accent/50 flex-shrink-0"
+    />
+    <span className="text-sm text-gray-300 truncate flex-1">{fileName}</span>
+    <span className="text-xs text-gray-500 flex-shrink-0">{formatBytes(sizeBytes)}</span>
+  </button>
+);
+
+export default Blueprints;

--- a/components/pages/Blueprints/index.tsx
+++ b/components/pages/Blueprints/index.tsx
@@ -275,7 +275,7 @@ const Blueprints: React.FC = () => {
       <div className="flex flex-col h-full min-h-0">
         {/* ── Header ───────────────────────────────────────────────────────── */}
         <div className="flex items-center justify-between mb-4 flex-shrink-0">
-          <h1 className="font-display text-3xl font-bold uppercase text-white tracking-wider">Blueprints</h1>
+          <h1 className="font-display text-3xl font-bold uppercase text-white tracking-wider">Catalog</h1>
           <div className="flex items-center gap-3">
             {/* Installation selector */}
             {instances.length > 0 && (

--- a/components/pages/Blueprints/index.tsx
+++ b/components/pages/Blueprints/index.tsx
@@ -35,24 +35,17 @@ type CatalogItemRef =
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
-const formatBytes = (v: number): string => {
-  if (v < 1024) return `${v} B`;
-  const kb = v / 1024;
-  if (kb < 1024) return `${kb.toFixed(1)} KB`;
-  return `${(kb / 1024).toFixed(2)} MB`;
-};
-
 const TYPE_COLORS: Record<string, string> = {
   SHIP: 'bg-blue-500/20 text-blue-300 border-blue-500/30',
   SPACE_STATION: 'bg-purple-500/20 text-purple-300 border-purple-500/30',
-  SHOP: 'bg-yellow-500/20 text-yellow-300 border-yellow-500/30',
+  /*SHOP: 'bg-yellow-500/20 text-yellow-300 border-yellow-500/30',
   ASTEROID: 'bg-gray-500/20 text-gray-300 border-gray-500/30',
   MANAGED_ASTEROID: 'bg-gray-500/20 text-gray-300 border-gray-500/30',
-  PLANET: 'bg-green-500/20 text-green-300 border-green-500/30',
+  PLANET: 'bg-green-500/20 text-green-300 border-green-500/30',*/ //users cant actaully save these in game anyways
   UNKNOWN: 'bg-slate-500/20 text-slate-300 border-slate-500/30',
 };
 
-const ALL_TYPES = ['SHIP', 'SPACE_STATION', 'SHOP', 'ASTEROID', 'MANAGED_ASTEROID', 'PLANET', 'UNKNOWN'];
+const ALL_TYPES = ['SHIP', 'SPACE_STATION', /*'SHOP', 'ASTEROID', 'MANAGED_ASTEROID', 'PLANET',*/ 'UNKNOWN'];
 const typeLabel = (t: string) => t.replace(/_/g, ' ');
 
 const STORE_KEY = 'blueprintsCatalogPath';
@@ -104,12 +97,12 @@ const Blueprints: React.FC = () => {
     [instances, selectedInstanceId],
   );
 
-  // ── Data loading ──────────────────────────────────────────────────────────
-  const loadCatalog = useCallback(async () => {
+  // ── Data loading (uses backend cache; Refresh buttons pass invalidate=true) ─
+  const loadCatalog = useCallback(async (invalidate = false) => {
     if (!catalogPath) return;
     setIsLoadingCatalog(true);
     try {
-      const data = await launcher.catalog.list(catalogPath);
+      const data = await launcher.catalog.list(catalogPath, invalidate);
       setCatalogData(data);
       if (data.error) setError(data.error);
     } catch (err) {
@@ -119,11 +112,11 @@ const Blueprints: React.FC = () => {
     }
   }, [launcher, catalogPath]);
 
-  const loadInstall = useCallback(async () => {
+  const loadInstall = useCallback(async (invalidate = false) => {
     if (!selectedInstance?.path) { setInstallData(null); return; }
     setIsLoadingInstall(true);
     try {
-      const data = await launcher.catalog.listInstallation(selectedInstance.path);
+      const data = await launcher.catalog.listInstallation(selectedInstance.path, invalidate);
       setInstallData(data);
     } catch (err) {
       setError(`Failed to load installation blueprints: ${String(err)}`);
@@ -395,7 +388,7 @@ const Blueprints: React.FC = () => {
                   <button onClick={handleDeleteSelected} disabled={isBusy || catalogSelection.size === 0} className="p-1.5 rounded-md hover:bg-red-500/20 transition-colors text-gray-400 hover:text-red-400 disabled:opacity-40" title="Delete selected">
                     <TrashIcon className="w-4 h-4" />
                   </button>
-                  <button onClick={() => void loadCatalog()} disabled={isLoadingCatalog} className="px-2 py-1 text-xs rounded bg-white/5 hover:bg-white/10 transition-colors text-gray-400">
+                  <button onClick={() => void loadCatalog(true)} disabled={isLoadingCatalog} className="px-2 py-1 text-xs rounded bg-white/5 hover:bg-white/10 transition-colors text-gray-400">
                     {isLoadingCatalog ? 'Loading...' : 'Refresh'}
                   </button>
                 </div>
@@ -409,7 +402,7 @@ const Blueprints: React.FC = () => {
                 {catalogExported.length > 0 && (
                   <div className="pt-2">
                     <p className="text-xs text-gray-500 uppercase tracking-wider mb-1 px-2">Exported (.sment)</p>
-                    {catalogExported.map((exp) => { const key = `exp:${exp.fileName}`; return <FileRow key={key} fileName={exp.fileName} sizeBytes={exp.sizeBytes} selected={catalogSelection.has(key)} onToggle={() => toggleCatalogItem(key)} onDragStart={(e) => handleDragStart(e, key, 'catalog')} />; })}
+                    {catalogExported.map((exp) => { const key = `exp:${exp.fileName}`; return <FileRow key={key} fileName={exp.fileName} selected={catalogSelection.has(key)} onToggle={() => toggleCatalogItem(key)} onDragStart={(e) => handleDragStart(e, key, 'catalog')} />; })}
                   </div>
                 )}
               </div>
@@ -444,7 +437,7 @@ const Blueprints: React.FC = () => {
                   <button onClick={installSelection.size === allInstallKeys.length ? deselectAllInstall : selectAllInstall} className="px-2 py-1 text-xs rounded bg-white/5 hover:bg-white/10 transition-colors text-gray-400" title={installSelection.size === allInstallKeys.length ? 'Deselect all' : 'Select all'}>
                     <CheckIcon className="w-3 h-3 inline mr-1" />{installSelection.size === allInstallKeys.length ? 'None' : 'All'}
                   </button>
-                  <button onClick={() => void loadInstall()} disabled={isLoadingInstall} className="px-2 py-1 text-xs rounded bg-white/5 hover:bg-white/10 transition-colors text-gray-400">
+                  <button onClick={() => void loadInstall(true)} disabled={isLoadingInstall} className="px-2 py-1 text-xs rounded bg-white/5 hover:bg-white/10 transition-colors text-gray-400">
                     {isLoadingInstall ? 'Loading...' : 'Refresh'}
                   </button>
                 </div>
@@ -459,7 +452,7 @@ const Blueprints: React.FC = () => {
                 {installExported.length > 0 && (
                   <div className="pt-2">
                     <p className="text-xs text-gray-500 uppercase tracking-wider mb-1 px-2">Exported (.sment)</p>
-                    {installExported.map((exp) => { const key = `exp:${exp.fileName}`; return <FileRow key={key} fileName={exp.fileName} sizeBytes={exp.sizeBytes} selected={installSelection.has(key)} onToggle={() => toggleInstallItem(key)} onDragStart={(e) => handleDragStart(e, key, 'install')} />; })}
+                    {installExported.map((exp) => { const key = `exp:${exp.fileName}`; return <FileRow key={key} fileName={exp.fileName} selected={installSelection.has(key)} onToggle={() => toggleInstallItem(key)} onDragStart={(e) => handleDragStart(e, key, 'install')} />; })}
                   </div>
                 )}
               </div>
@@ -485,7 +478,6 @@ const BlueprintRow: React.FC<{ bp: BlueprintMeta; selected: boolean; onToggle: (
           {bp.classification && <span className="text-[10px] uppercase tracking-wider text-gray-400">{bp.classification.replace(/_/g, ' ')}</span>}
         </div>
         <div className="flex items-center gap-3 mt-0.5 text-xs text-gray-500">
-          <span>{formatBytes(bp.sizeBytes)}</span>
           {bp.elementCount != null && <span>{bp.elementCount.toLocaleString()} blocks</span>}
           {bp.dockedCount > 0 && <span>{bp.dockedCount} docked</span>}
         </div>
@@ -494,11 +486,10 @@ const BlueprintRow: React.FC<{ bp: BlueprintMeta; selected: boolean; onToggle: (
   );
 };
 
-const FileRow: React.FC<{ fileName: string; sizeBytes: number; selected: boolean; onToggle: () => void; onDragStart?: (e: React.DragEvent) => void }> = ({ fileName, sizeBytes, selected, onToggle, onDragStart }) => (
+const FileRow: React.FC<{ fileName: string; selected: boolean; onToggle: () => void; onDragStart?: (e: React.DragEvent) => void }> = ({ fileName, selected, onToggle, onDragStart }) => (
   <button draggable onDragStart={onDragStart} onClick={onToggle} className={`w-full text-left px-3 py-1.5 rounded-lg border transition-colors flex items-center gap-3 cursor-grab active:cursor-grabbing ${selected ? 'bg-starmade-accent/15 border-starmade-accent/40' : 'bg-black/20 border-white/5 hover:bg-white/5'}`}>
     <input type="checkbox" checked={selected} onChange={onToggle} onClick={(e) => e.stopPropagation()} className="rounded border-gray-600 bg-gray-800 text-starmade-accent focus:ring-starmade-accent/50 flex-shrink-0" />
     <span className="text-sm text-gray-300 truncate flex-1">{fileName}</span>
-    <span className="text-xs text-gray-500 flex-shrink-0">{formatBytes(sizeBytes)}</span>
   </button>
 );
 

--- a/components/pages/Settings/LauncherSettings.tsx
+++ b/components/pages/Settings/LauncherSettings.tsx
@@ -95,8 +95,11 @@ const LauncherSettings: React.FC = () => {
     const [isLoadingBackups, setIsLoadingBackups] = useState(false);
     const [isRestoringBackup, setIsRestoringBackup] = useState(false);
 
-    // ── Blueprint catalog path ──────────────────────────────────────────────
-    const [catalogPath, setCatalogPath] = useState<string>('');
+    // ── Blueprint / Template catalog paths ─────────────────────────────────
+    const [blueprintsCatalogPath, setBlueprintsCatalogPath] = useState<string>('');
+    const [templatesCatalogPath, setTemplatesCatalogPath] = useState<string>('');
+    const [autoSyncBlueprints, setAutoSyncBlueprints] = useState(false);
+    const [autoSyncTemplates, setAutoSyncTemplates] = useState(false);
 
     const languageOptions = [
         { value: 'English', label: 'English' }, //Todo: Support other languages, and maybe have this set the game's language if possible
@@ -138,9 +141,18 @@ const LauncherSettings: React.FC = () => {
                 .catch(() => {});
         }
         
-        // Load catalog path
-        window.launcher.store.get('catalogPath').then((val) => {
-            if (typeof val === 'string') setCatalogPath(val);
+        // Load catalog paths and sync settings
+        window.launcher.store.get('blueprintsCatalogPath').then((val) => {
+            if (typeof val === 'string') setBlueprintsCatalogPath(val);
+        }).catch(() => {});
+        window.launcher.store.get('templatesCatalogPath').then((val) => {
+            if (typeof val === 'string') setTemplatesCatalogPath(val);
+        }).catch(() => {});
+        window.launcher.store.get('autoSyncBlueprints').then((val) => {
+            if (typeof val === 'boolean') setAutoSyncBlueprints(val);
+        }).catch(() => {});
+        window.launcher.store.get('autoSyncTemplates').then((val) => {
+            if (typeof val === 'boolean') setAutoSyncTemplates(val);
         }).catch(() => {});
 
         // Load Java runtimes
@@ -734,17 +746,17 @@ const LauncherSettings: React.FC = () => {
 
                 <div className="mt-8">
                     <h2 className="font-display text-xl font-bold uppercase tracking-wider text-starmade-text-accent mb-4 pb-2 border-b-2 border-starmade-accent/30">
-                        Blueprint Catalog
+                        Blueprints &amp; Templates
                     </h2>
                     <div className="space-y-4">
                         <SettingRow
-                            title="Catalog Directory"
-                            description="Central directory for storing and sharing blueprints and templates across installations."
+                            title="Blueprints Catalog Directory"
+                            description="Central directory for storing and sharing blueprints across installations."
                         >
                             <div className="flex items-center gap-2">
-                                {catalogPath && (
+                                {blueprintsCatalogPath && (
                                     <button
-                                        onClick={() => window.launcher?.shell?.openPath(catalogPath)}
+                                        onClick={() => window.launcher?.shell?.openPath(blueprintsCatalogPath)}
                                         className="px-3 py-2 rounded-md bg-slate-700 hover:bg-slate-600 text-sm transition-colors"
                                         title="Open in file manager"
                                     >
@@ -753,10 +765,10 @@ const LauncherSettings: React.FC = () => {
                                 )}
                                 <button
                                     onClick={async () => {
-                                        const selected = await window.launcher?.dialog?.openFolder(catalogPath || undefined);
+                                        const selected = await window.launcher?.dialog?.openFolder(blueprintsCatalogPath || undefined);
                                         if (selected) {
-                                            setCatalogPath(selected);
-                                            await window.launcher?.store?.set('catalogPath', selected);
+                                            setBlueprintsCatalogPath(selected);
+                                            await window.launcher?.store?.set('blueprintsCatalogPath', selected);
                                         }
                                     }}
                                     className="px-4 py-2 rounded-md bg-starmade-accent hover:bg-starmade-accent/80 transition-colors text-sm font-semibold uppercase tracking-wider"
@@ -765,12 +777,70 @@ const LauncherSettings: React.FC = () => {
                                 </button>
                             </div>
                         </SettingRow>
-                        {catalogPath && (
+                        {blueprintsCatalogPath && (
                             <div className="bg-black/20 p-3 rounded-lg border border-white/10">
-                                <p className="text-xs text-gray-400 uppercase tracking-wider mb-1">Current Path</p>
-                                <p className="text-sm text-gray-200 font-mono break-all">{catalogPath}</p>
+                                <p className="text-xs text-gray-400 uppercase tracking-wider mb-1">Blueprints Path</p>
+                                <p className="text-sm text-gray-200 font-mono break-all">{blueprintsCatalogPath}</p>
                             </div>
                         )}
+                        <SettingRow
+                            title="Templates Catalog Directory"
+                            description="Central directory for storing and sharing templates across installations."
+                        >
+                            <div className="flex items-center gap-2">
+                                {templatesCatalogPath && (
+                                    <button
+                                        onClick={() => window.launcher?.shell?.openPath(templatesCatalogPath)}
+                                        className="px-3 py-2 rounded-md bg-slate-700 hover:bg-slate-600 text-sm transition-colors"
+                                        title="Open in file manager"
+                                    >
+                                        <FolderIcon className="w-4 h-4" />
+                                    </button>
+                                )}
+                                <button
+                                    onClick={async () => {
+                                        const selected = await window.launcher?.dialog?.openFolder(templatesCatalogPath || undefined);
+                                        if (selected) {
+                                            setTemplatesCatalogPath(selected);
+                                            await window.launcher?.store?.set('templatesCatalogPath', selected);
+                                        }
+                                    }}
+                                    className="px-4 py-2 rounded-md bg-starmade-accent hover:bg-starmade-accent/80 transition-colors text-sm font-semibold uppercase tracking-wider"
+                                >
+                                    Browse
+                                </button>
+                            </div>
+                        </SettingRow>
+                        {templatesCatalogPath && (
+                            <div className="bg-black/20 p-3 rounded-lg border border-white/10">
+                                <p className="text-xs text-gray-400 uppercase tracking-wider mb-1">Templates Path</p>
+                                <p className="text-sm text-gray-200 font-mono break-all">{templatesCatalogPath}</p>
+                            </div>
+                        )}
+                        <SettingRow
+                            title="Auto-Sync Blueprints"
+                            description="Automatically sync blueprints from catalog to installations on launch. Conflicts will prompt for confirmation."
+                        >
+                            <ToggleSwitch
+                                checked={autoSyncBlueprints}
+                                onChange={async (val) => {
+                                    setAutoSyncBlueprints(val);
+                                    await window.launcher?.store?.set('autoSyncBlueprints', val);
+                                }}
+                            />
+                        </SettingRow>
+                        <SettingRow
+                            title="Auto-Sync Templates"
+                            description="Automatically sync templates from catalog to installations on launch. Conflicts will prompt for confirmation."
+                        >
+                            <ToggleSwitch
+                                checked={autoSyncTemplates}
+                                onChange={async (val) => {
+                                    setAutoSyncTemplates(val);
+                                    await window.launcher?.store?.set('autoSyncTemplates', val);
+                                }}
+                            />
+                        </SettingRow>
                     </div>
                 </div>
 

--- a/components/pages/Settings/LauncherSettings.tsx
+++ b/components/pages/Settings/LauncherSettings.tsx
@@ -95,6 +95,9 @@ const LauncherSettings: React.FC = () => {
     const [isLoadingBackups, setIsLoadingBackups] = useState(false);
     const [isRestoringBackup, setIsRestoringBackup] = useState(false);
 
+    // ── Blueprint catalog path ──────────────────────────────────────────────
+    const [catalogPath, setCatalogPath] = useState<string>('');
+
     const languageOptions = [
         { value: 'English', label: 'English' }, //Todo: Support other languages, and maybe have this set the game's language if possible
     ];
@@ -135,6 +138,11 @@ const LauncherSettings: React.FC = () => {
                 .catch(() => {});
         }
         
+        // Load catalog path
+        window.launcher.store.get('catalogPath').then((val) => {
+            if (typeof val === 'string') setCatalogPath(val);
+        }).catch(() => {});
+
         // Load Java runtimes
         loadJavaRuntimes();
 
@@ -722,6 +730,48 @@ const LauncherSettings: React.FC = () => {
                             })}
                         </div>
                     )}
+                </div>
+
+                <div className="mt-8">
+                    <h2 className="font-display text-xl font-bold uppercase tracking-wider text-starmade-text-accent mb-4 pb-2 border-b-2 border-starmade-accent/30">
+                        Blueprint Catalog
+                    </h2>
+                    <div className="space-y-4">
+                        <SettingRow
+                            title="Catalog Directory"
+                            description="Central directory for storing and sharing blueprints and templates across installations."
+                        >
+                            <div className="flex items-center gap-2">
+                                {catalogPath && (
+                                    <button
+                                        onClick={() => window.launcher?.shell?.openPath(catalogPath)}
+                                        className="px-3 py-2 rounded-md bg-slate-700 hover:bg-slate-600 text-sm transition-colors"
+                                        title="Open in file manager"
+                                    >
+                                        <FolderIcon className="w-4 h-4" />
+                                    </button>
+                                )}
+                                <button
+                                    onClick={async () => {
+                                        const selected = await window.launcher?.dialog?.openFolder(catalogPath || undefined);
+                                        if (selected) {
+                                            setCatalogPath(selected);
+                                            await window.launcher?.store?.set('catalogPath', selected);
+                                        }
+                                    }}
+                                    className="px-4 py-2 rounded-md bg-starmade-accent hover:bg-starmade-accent/80 transition-colors text-sm font-semibold uppercase tracking-wider"
+                                >
+                                    Browse
+                                </button>
+                            </div>
+                        </SettingRow>
+                        {catalogPath && (
+                            <div className="bg-black/20 p-3 rounded-lg border border-white/10">
+                                <p className="text-xs text-gray-400 uppercase tracking-wider mb-1">Current Path</p>
+                                <p className="text-sm text-gray-200 font-mono break-all">{catalogPath}</p>
+                            </div>
+                        )}
+                    </div>
                 </div>
 
                 <div className="mt-8">

--- a/components/pages/Templates/index.tsx
+++ b/components/pages/Templates/index.tsx
@@ -2,36 +2,22 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import PageContainer from '../../common/PageContainer';
 import CustomDropdown from '../../common/CustomDropdown';
 import { useData } from '../../../contexts/DataContext';
-import { FolderIcon, TrashIcon, ArchiveIcon, CheckIcon } from '../../common/icons';
+import { FolderIcon, TrashIcon, CheckIcon } from '../../common/icons';
 import type { ManagedItem } from '../../../types';
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
-interface BlueprintMeta {
-  name: string;
-  type: string;
-  classification?: string;
-  boundingBox?: { min: [number, number, number]; max: [number, number, number] };
-  elementCount?: number;
-  sizeBytes: number;
-  modifiedMs: number;
-  dockedCount: number;
-}
-
-interface ExportedMeta { fileName: string; sizeBytes: number; modifiedMs: number; }
+interface TemplateMeta { fileName: string; sizeBytes: number; modifiedMs: number; }
 
 interface CatalogListing {
   catalogPath: string;
-  blueprints: BlueprintMeta[];
-  exported: ExportedMeta[];
-  templates: Array<{ fileName: string; sizeBytes: number; modifiedMs: number }>;
+  blueprints: unknown[];
+  exported: unknown[];
+  templates: TemplateMeta[];
   error?: string;
 }
 
-type CatalogItemRef =
-  | { kind: 'blueprint'; name: string }
-  | { kind: 'exported'; fileName: string }
-  | { kind: 'template'; fileName: string };
+type CatalogItemRef = { kind: 'template'; fileName: string };
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
@@ -42,24 +28,11 @@ const formatBytes = (v: number): string => {
   return `${(kb / 1024).toFixed(2)} MB`;
 };
 
-const TYPE_COLORS: Record<string, string> = {
-  SHIP: 'bg-blue-500/20 text-blue-300 border-blue-500/30',
-  SPACE_STATION: 'bg-purple-500/20 text-purple-300 border-purple-500/30',
-  SHOP: 'bg-yellow-500/20 text-yellow-300 border-yellow-500/30',
-  ASTEROID: 'bg-gray-500/20 text-gray-300 border-gray-500/30',
-  MANAGED_ASTEROID: 'bg-gray-500/20 text-gray-300 border-gray-500/30',
-  PLANET: 'bg-green-500/20 text-green-300 border-green-500/30',
-  UNKNOWN: 'bg-slate-500/20 text-slate-300 border-slate-500/30',
-};
-
-const ALL_TYPES = ['SHIP', 'SPACE_STATION', 'SHOP', 'ASTEROID', 'MANAGED_ASTEROID', 'PLANET', 'UNKNOWN'];
-const typeLabel = (t: string) => t.replace(/_/g, ' ');
-
-const STORE_KEY = 'blueprintsCatalogPath';
+const STORE_KEY = 'templatesCatalogPath';
 
 // ─── Component ──────────────────────────────────────────────────────────────
 
-const Blueprints: React.FC = () => {
+const Templates: React.FC = () => {
   const { installations, selectedInstallationId } = useData();
 
   const [selectedInstanceId, setSelectedInstanceId] = useState<string | null>(selectedInstallationId);
@@ -74,13 +47,10 @@ const Blueprints: React.FC = () => {
   const [status, setStatus] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [isBusy, setIsBusy] = useState(false);
-  // Search & filters
   const [searchQuery, setSearchQuery] = useState('');
-  const [typeFilter, setTypeFilter] = useState<string>('ALL');
 
   const launcher = window.launcher;
 
-  // Load catalog path from store
   useEffect(() => {
     launcher.store.get(STORE_KEY).then((val) => {
       if (typeof val === 'string') setCatalogPath(val);
@@ -126,7 +96,7 @@ const Blueprints: React.FC = () => {
       const data = await launcher.catalog.listInstallation(selectedInstance.path);
       setInstallData(data);
     } catch (err) {
-      setError(`Failed to load installation blueprints: ${String(err)}`);
+      setError(`Failed to load installation templates: ${String(err)}`);
     } finally {
       setIsLoadingInstall(false);
     }
@@ -136,43 +106,18 @@ const Blueprints: React.FC = () => {
   useEffect(() => { void loadInstall(); }, [loadInstall]);
 
   // ── Filtering ─────────────────────────────────────────────────────────────
-  const filterBlueprints = (list: BlueprintMeta[]) => {
-    let filtered = list;
-    if (searchQuery) {
-      const q = searchQuery.toLowerCase();
-      filtered = filtered.filter((bp) => bp.name.toLowerCase().includes(q));
-    }
-    if (typeFilter !== 'ALL') {
-      filtered = filtered.filter((bp) => bp.type === typeFilter);
-    }
-    return filtered;
-  };
-
-  const filterExported = (list: ExportedMeta[]) => {
+  const filterTemplates = (list: TemplateMeta[]) => {
     if (!searchQuery) return list;
     const q = searchQuery.toLowerCase();
-    return list.filter((e) => e.fileName.toLowerCase().includes(q));
+    return list.filter((t) => t.fileName.toLowerCase().includes(q));
   };
 
-  const catalogBlueprints = useMemo(() => filterBlueprints(catalogData?.blueprints ?? []), [catalogData, searchQuery, typeFilter]);
-  const catalogExported = useMemo(() => filterExported(catalogData?.exported ?? []), [catalogData, searchQuery]);
-  const installBlueprints = useMemo(() => filterBlueprints(installData?.blueprints ?? []), [installData, searchQuery, typeFilter]);
-  const installExported = useMemo(() => filterExported(installData?.exported ?? []), [installData, searchQuery]);
+  const catalogTemplates = useMemo(() => filterTemplates(catalogData?.templates ?? []), [catalogData, searchQuery]);
+  const installTemplates = useMemo(() => filterTemplates(installData?.templates ?? []), [installData, searchQuery]);
 
   // ── Select all helpers ────────────────────────────────────────────────────
-  const allCatalogKeys = useMemo(() => {
-    const keys: string[] = [];
-    for (const bp of catalogBlueprints) keys.push(`bp:${bp.name}`);
-    for (const exp of catalogExported) keys.push(`exp:${exp.fileName}`);
-    return keys;
-  }, [catalogBlueprints, catalogExported]);
-
-  const allInstallKeys = useMemo(() => {
-    const keys: string[] = [];
-    for (const bp of installBlueprints) keys.push(`bp:${bp.name}`);
-    for (const exp of installExported) keys.push(`exp:${exp.fileName}`);
-    return keys;
-  }, [installBlueprints, installExported]);
+  const allCatalogKeys = useMemo(() => catalogTemplates.map((t) => `tpl:${t.fileName}`), [catalogTemplates]);
+  const allInstallKeys = useMemo(() => installTemplates.map((t) => `tpl:${t.fileName}`), [installTemplates]);
 
   const toggleCatalogItem = (key: string) => {
     setCatalogSelection((prev) => { const next = new Set(prev); if (next.has(key)) next.delete(key); else next.add(key); return next; });
@@ -185,18 +130,13 @@ const Blueprints: React.FC = () => {
   const selectAllInstall = () => setInstallSelection(new Set(allInstallKeys));
   const deselectAllInstall = () => setInstallSelection(new Set());
 
-  const catalogItemRefFromKey = (key: string): CatalogItemRef => {
-    if (key.startsWith('bp:')) return { kind: 'blueprint', name: key.slice(3) };
-    if (key.startsWith('exp:')) return { kind: 'exported', fileName: key.slice(4) };
-    return { kind: 'template', fileName: key.slice(4) };
-  };
+  const refFromKey = (key: string): CatalogItemRef => ({ kind: 'template', fileName: key.slice(4) });
 
   // ── Drag & drop ───────────────────────────────────────────────────────────
   const [dragOverPanel, setDragOverPanel] = useState<'catalog' | 'install' | null>(null);
 
   const handleDragStart = (e: React.DragEvent, key: string, source: 'catalog' | 'install') => {
     const selection = source === 'catalog' ? catalogSelection : installSelection;
-    // If dragged item is selected, drag all selected; otherwise just this one
     const keys = selection.has(key) ? Array.from(selection) : [key];
     e.dataTransfer.setData('application/x-catalog-keys', JSON.stringify(keys));
     e.dataTransfer.setData('application/x-catalog-source', source);
@@ -204,8 +144,7 @@ const Blueprints: React.FC = () => {
   };
 
   const handleDragOver = (e: React.DragEvent, panel: 'catalog' | 'install') => {
-    const source = e.dataTransfer.types.includes('application/x-catalog-source') ? 'ok' : null;
-    if (!source) return;
+    if (!e.dataTransfer.types.includes('application/x-catalog-source')) return;
     e.preventDefault();
     e.dataTransfer.dropEffect = 'copy';
     setDragOverPanel(panel);
@@ -217,26 +156,24 @@ const Blueprints: React.FC = () => {
     e.preventDefault();
     setDragOverPanel(null);
     const source = e.dataTransfer.getData('application/x-catalog-source');
-    if (source === targetPanel) return; // same panel, no-op
+    if (source === targetPanel) return;
     const keys: string[] = JSON.parse(e.dataTransfer.getData('application/x-catalog-keys') || '[]');
     if (keys.length === 0) return;
 
-    const items = keys.map(catalogItemRefFromKey);
+    const items = keys.map(refFromKey);
     setIsBusy(true); setStatus(null); setError(null);
     try {
       if (targetPanel === 'install') {
-        // Catalog → Installation (deploy)
         if (!selectedInstance || !catalogPath) return;
         const result = await launcher.catalog.deploy(catalogPath, items, [selectedInstance.path], overwrite);
-        if (result.success) setStatus(`Deployed ${result.copiedCount ?? 0} item(s)${result.skippedCount ? `, skipped ${result.skippedCount}` : ''}`);
+        if (result.success) setStatus(`Deployed ${result.copiedCount ?? 0} template(s)${result.skippedCount ? `, skipped ${result.skippedCount}` : ''}`);
         else setError(result.errors?.join('; ') ?? 'Deploy failed');
         setCatalogSelection(new Set());
         void loadInstall();
       } else {
-        // Installation → Catalog (import)
         if (!selectedInstance || !catalogPath) return;
         const result = await launcher.catalog.import(catalogPath, selectedInstance.path, items, overwrite);
-        if (result.success) setStatus(`Imported ${result.copiedCount ?? 0} item(s)${result.skippedCount ? `, skipped ${result.skippedCount}` : ''}`);
+        if (result.success) setStatus(`Imported ${result.copiedCount ?? 0} template(s)${result.skippedCount ? `, skipped ${result.skippedCount}` : ''}`);
         else setError(result.errors?.join('; ') ?? 'Import failed');
         setInstallSelection(new Set());
         void loadCatalog();
@@ -249,9 +186,9 @@ const Blueprints: React.FC = () => {
     if (!selectedInstance || catalogSelection.size === 0 || !catalogPath) return;
     setIsBusy(true); setStatus(null); setError(null);
     try {
-      const items = Array.from(catalogSelection).map(catalogItemRefFromKey);
+      const items = Array.from(catalogSelection).map(refFromKey);
       const result = await launcher.catalog.deploy(catalogPath, items, [selectedInstance.path], overwrite);
-      if (result.success) setStatus(`Deployed ${result.copiedCount ?? 0} item(s)${result.skippedCount ? `, skipped ${result.skippedCount}` : ''}`);
+      if (result.success) setStatus(`Deployed ${result.copiedCount ?? 0} template(s)${result.skippedCount ? `, skipped ${result.skippedCount}` : ''}`);
       else setError(result.errors?.join('; ') ?? 'Deploy failed');
       setCatalogSelection(new Set());
       void loadInstall();
@@ -262,9 +199,9 @@ const Blueprints: React.FC = () => {
     if (!selectedInstance || installSelection.size === 0 || !catalogPath) return;
     setIsBusy(true); setStatus(null); setError(null);
     try {
-      const items = Array.from(installSelection).map(catalogItemRefFromKey);
+      const items = Array.from(installSelection).map(refFromKey);
       const result = await launcher.catalog.import(catalogPath, selectedInstance.path, items, overwrite);
-      if (result.success) setStatus(`Imported ${result.copiedCount ?? 0} item(s)${result.skippedCount ? `, skipped ${result.skippedCount}` : ''}`);
+      if (result.success) setStatus(`Imported ${result.copiedCount ?? 0} template(s)${result.skippedCount ? `, skipped ${result.skippedCount}` : ''}`);
       else setError(result.errors?.join('; ') ?? 'Import failed');
       setInstallSelection(new Set());
       void loadCatalog();
@@ -278,27 +215,14 @@ const Blueprints: React.FC = () => {
     const errs: string[] = [];
     for (const key of catalogSelection) {
       try {
-        const r = await launcher.catalog.delete(catalogPath, catalogItemRefFromKey(key));
+        const r = await launcher.catalog.delete(catalogPath, refFromKey(key));
         if (r.success) deleted++; else if (r.error) errs.push(r.error);
       } catch (err) { errs.push(String(err)); }
     }
-    if (errs.length) setError(errs.join('; ')); else setStatus(`Deleted ${deleted} item(s) from catalog`);
+    if (errs.length) setError(errs.join('; ')); else setStatus(`Deleted ${deleted} template(s) from catalog`);
     setCatalogSelection(new Set());
     void loadCatalog();
     setIsBusy(false);
-  };
-
-  const handleImportSment = async () => {
-    if (!catalogPath) return;
-    const selected = await launcher.dialog.openFile(undefined, undefined as unknown as 'image');
-    if (!selected || !selected.endsWith('.sment')) { if (selected) setError('Please select a .sment file'); return; }
-    setIsBusy(true); setStatus(null); setError(null);
-    try {
-      const result = await launcher.catalog.importSment(catalogPath, selected);
-      if (result.success) setStatus(`Imported .sment file (${result.copiedCount ?? 0} item(s))`);
-      else setError(result.errors?.join('; ') ?? 'Import failed');
-      void loadCatalog();
-    } catch (err) { setError(String(err)); } finally { setIsBusy(false); }
   };
 
   const handleSetupCatalog = async () => {
@@ -311,13 +235,12 @@ const Blueprints: React.FC = () => {
 
   const noCatalog = !catalogPath;
 
-  // ── Render ────────────────────────────────────────────────────────────────
   return (
     <PageContainer closeTarget="Play" resizable>
       <div className="flex flex-col h-full min-h-0">
         {/* Header */}
         <div className="flex items-center justify-between mb-3 flex-shrink-0">
-          <h1 className="font-display text-3xl font-bold uppercase text-white tracking-wider">Blueprints</h1>
+          <h1 className="font-display text-3xl font-bold uppercase text-white tracking-wider">Templates</h1>
           <div className="flex items-center gap-3">
             {instances.length > 0 && (
               <CustomDropdown
@@ -330,7 +253,7 @@ const Blueprints: React.FC = () => {
           </div>
         </div>
 
-        {/* Search + filter bar */}
+        {/* Search bar */}
         {!noCatalog && (
           <div className="flex items-center gap-3 mb-3 flex-shrink-0">
             <input
@@ -339,12 +262,6 @@ const Blueprints: React.FC = () => {
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
               className="flex-1 px-3 py-1.5 rounded-lg bg-black/30 border border-white/10 text-sm text-white placeholder-gray-500 focus:outline-none focus:border-starmade-accent/50"
-            />
-            <CustomDropdown
-              options={[{ value: 'ALL', label: 'All Types' }, ...ALL_TYPES.map((t) => ({ value: t, label: typeLabel(t) }))]}
-              value={typeFilter}
-              onChange={setTypeFilter}
-              className="w-44"
             />
           </div>
         )}
@@ -361,10 +278,10 @@ const Blueprints: React.FC = () => {
         {noCatalog && (
           <div className="flex-1 flex items-center justify-center">
             <div className="text-center space-y-4">
-              <p className="text-gray-400 text-lg">No blueprints catalog directory configured.</p>
-              <p className="text-gray-500 text-sm">Choose a directory to store your centralized blueprint collection.</p>
+              <p className="text-gray-400 text-lg">No templates catalog directory configured.</p>
+              <p className="text-gray-500 text-sm">Choose a directory to store your centralized template collection.</p>
               <button onClick={handleSetupCatalog} className="px-6 py-3 rounded-lg bg-starmade-accent hover:bg-starmade-accent/80 transition-colors font-semibold uppercase tracking-wider">
-                Choose Blueprints Folder
+                Choose Templates Folder
               </button>
             </div>
           </div>
@@ -383,11 +300,8 @@ const Blueprints: React.FC = () => {
               <div className="flex items-center justify-between mb-2">
                 <h2 className="font-display text-sm font-bold uppercase tracking-wider text-starmade-text-accent">Catalog</h2>
                 <div className="flex items-center gap-1">
-                  <button onClick={catalogSelection.size === allCatalogKeys.length ? deselectAllCatalog : selectAllCatalog} className="px-2 py-1 text-xs rounded bg-white/5 hover:bg-white/10 transition-colors text-gray-400" title={catalogSelection.size === allCatalogKeys.length ? 'Deselect all' : 'Select all'}>
+                  <button onClick={catalogSelection.size === allCatalogKeys.length ? deselectAllCatalog : selectAllCatalog} className="px-2 py-1 text-xs rounded bg-white/5 hover:bg-white/10 transition-colors text-gray-400">
                     <CheckIcon className="w-3 h-3 inline mr-1" />{catalogSelection.size === allCatalogKeys.length ? 'None' : 'All'}
-                  </button>
-                  <button onClick={handleImportSment} disabled={isBusy} className="p-1.5 rounded-md hover:bg-white/10 transition-colors text-gray-400 hover:text-white disabled:opacity-40" title="Import .sment file">
-                    <ArchiveIcon className="w-4 h-4" />
                   </button>
                   <button onClick={() => launcher.shell.openPath(catalogPath)} className="p-1.5 rounded-md hover:bg-white/10 transition-colors text-gray-400 hover:text-white" title="Open catalog folder">
                     <FolderIcon className="w-4 h-4" />
@@ -402,25 +316,19 @@ const Blueprints: React.FC = () => {
               </div>
               <div className="flex-1 overflow-y-auto space-y-1 pr-1">
                 {isLoadingCatalog && <p className="text-gray-500 text-sm p-4 text-center">Loading catalog...</p>}
-                {!isLoadingCatalog && catalogBlueprints.length === 0 && catalogExported.length === 0 && (
-                  <p className="text-gray-500 text-sm p-4 text-center">{searchQuery || typeFilter !== 'ALL' ? 'No matches.' : 'Catalog is empty. Import blueprints from an installation or a .sment file.'}</p>
+                {!isLoadingCatalog && catalogTemplates.length === 0 && (
+                  <p className="text-gray-500 text-sm p-4 text-center">{searchQuery ? 'No matches.' : 'Catalog is empty. Import templates from an installation.'}</p>
                 )}
-                {catalogBlueprints.map((bp) => { const key = `bp:${bp.name}`; return <BlueprintRow key={key} bp={bp} selected={catalogSelection.has(key)} onToggle={() => toggleCatalogItem(key)} onDragStart={(e) => handleDragStart(e, key, 'catalog')} />; })}
-                {catalogExported.length > 0 && (
-                  <div className="pt-2">
-                    <p className="text-xs text-gray-500 uppercase tracking-wider mb-1 px-2">Exported (.sment)</p>
-                    {catalogExported.map((exp) => { const key = `exp:${exp.fileName}`; return <FileRow key={key} fileName={exp.fileName} sizeBytes={exp.sizeBytes} selected={catalogSelection.has(key)} onToggle={() => toggleCatalogItem(key)} onDragStart={(e) => handleDragStart(e, key, 'catalog')} />; })}
-                  </div>
-                )}
+                {catalogTemplates.map((tpl) => { const key = `tpl:${tpl.fileName}`; return <FileRow key={key} fileName={tpl.fileName} sizeBytes={tpl.sizeBytes} selected={catalogSelection.has(key)} onToggle={() => toggleCatalogItem(key)} onDragStart={(e) => handleDragStart(e, key, 'catalog')} />; })}
               </div>
             </div>
 
             {/* Center: Actions */}
             <div className="flex flex-col items-center justify-center gap-3 flex-shrink-0 px-1">
-              <button onClick={handleDeploy} disabled={isBusy || catalogSelection.size === 0 || !selectedInstance} className="px-3 py-2 rounded-lg bg-starmade-accent/80 hover:bg-starmade-accent disabled:opacity-30 disabled:cursor-not-allowed transition-colors text-sm font-semibold uppercase tracking-wider whitespace-nowrap" title="Deploy selected to installation">
+              <button onClick={handleDeploy} disabled={isBusy || catalogSelection.size === 0 || !selectedInstance} className="px-3 py-2 rounded-lg bg-starmade-accent/80 hover:bg-starmade-accent disabled:opacity-30 disabled:cursor-not-allowed transition-colors text-sm font-semibold uppercase tracking-wider whitespace-nowrap">
                 Deploy &rarr;
               </button>
-              <button onClick={handleImport} disabled={isBusy || installSelection.size === 0 || !selectedInstance} className="px-3 py-2 rounded-lg bg-starmade-accent/80 hover:bg-starmade-accent disabled:opacity-30 disabled:cursor-not-allowed transition-colors text-sm font-semibold uppercase tracking-wider whitespace-nowrap" title="Import selected to catalog">
+              <button onClick={handleImport} disabled={isBusy || installSelection.size === 0 || !selectedInstance} className="px-3 py-2 rounded-lg bg-starmade-accent/80 hover:bg-starmade-accent disabled:opacity-30 disabled:cursor-not-allowed transition-colors text-sm font-semibold uppercase tracking-wider whitespace-nowrap">
                 &larr; Import
               </button>
               <label className="flex items-center gap-1.5 text-xs text-gray-400 cursor-pointer mt-2">
@@ -441,7 +349,7 @@ const Blueprints: React.FC = () => {
                   Installation{selectedInstance ? `: ${selectedInstance.name}` : ''}
                 </h2>
                 <div className="flex items-center gap-1">
-                  <button onClick={installSelection.size === allInstallKeys.length ? deselectAllInstall : selectAllInstall} className="px-2 py-1 text-xs rounded bg-white/5 hover:bg-white/10 transition-colors text-gray-400" title={installSelection.size === allInstallKeys.length ? 'Deselect all' : 'Select all'}>
+                  <button onClick={installSelection.size === allInstallKeys.length ? deselectAllInstall : selectAllInstall} className="px-2 py-1 text-xs rounded bg-white/5 hover:bg-white/10 transition-colors text-gray-400">
                     <CheckIcon className="w-3 h-3 inline mr-1" />{installSelection.size === allInstallKeys.length ? 'None' : 'All'}
                   </button>
                   <button onClick={() => void loadInstall()} disabled={isLoadingInstall} className="px-2 py-1 text-xs rounded bg-white/5 hover:bg-white/10 transition-colors text-gray-400">
@@ -452,16 +360,10 @@ const Blueprints: React.FC = () => {
               <div className="flex-1 overflow-y-auto space-y-1 pr-1">
                 {!selectedInstance && <p className="text-gray-500 text-sm p-4 text-center">No installation selected.</p>}
                 {selectedInstance && isLoadingInstall && <p className="text-gray-500 text-sm p-4 text-center">Loading...</p>}
-                {selectedInstance && !isLoadingInstall && installBlueprints.length === 0 && installExported.length === 0 && (
-                  <p className="text-gray-500 text-sm p-4 text-center">{searchQuery || typeFilter !== 'ALL' ? 'No matches.' : 'No blueprints in this installation.'}</p>
+                {selectedInstance && !isLoadingInstall && installTemplates.length === 0 && (
+                  <p className="text-gray-500 text-sm p-4 text-center">{searchQuery ? 'No matches.' : 'No templates in this installation.'}</p>
                 )}
-                {installBlueprints.map((bp) => { const key = `bp:${bp.name}`; return <BlueprintRow key={key} bp={bp} selected={installSelection.has(key)} onToggle={() => toggleInstallItem(key)} onDragStart={(e) => handleDragStart(e, key, 'install')} />; })}
-                {installExported.length > 0 && (
-                  <div className="pt-2">
-                    <p className="text-xs text-gray-500 uppercase tracking-wider mb-1 px-2">Exported (.sment)</p>
-                    {installExported.map((exp) => { const key = `exp:${exp.fileName}`; return <FileRow key={key} fileName={exp.fileName} sizeBytes={exp.sizeBytes} selected={installSelection.has(key)} onToggle={() => toggleInstallItem(key)} onDragStart={(e) => handleDragStart(e, key, 'install')} />; })}
-                  </div>
-                )}
+                {installTemplates.map((tpl) => { const key = `tpl:${tpl.fileName}`; return <FileRow key={key} fileName={tpl.fileName} sizeBytes={tpl.sizeBytes} selected={installSelection.has(key)} onToggle={() => toggleInstallItem(key)} onDragStart={(e) => handleDragStart(e, key, 'install')} />; })}
               </div>
             </div>
           </div>
@@ -471,28 +373,7 @@ const Blueprints: React.FC = () => {
   );
 };
 
-// ─── Row sub-components ─────────────────────────────────────────────────────
-
-const BlueprintRow: React.FC<{ bp: BlueprintMeta; selected: boolean; onToggle: () => void; onDragStart?: (e: React.DragEvent) => void }> = ({ bp, selected, onToggle, onDragStart }) => {
-  const colors = TYPE_COLORS[bp.type] ?? TYPE_COLORS.UNKNOWN;
-  return (
-    <button draggable onDragStart={onDragStart} onClick={onToggle} className={`w-full text-left px-3 py-2 rounded-lg border transition-colors flex items-center gap-3 cursor-grab active:cursor-grabbing ${selected ? 'bg-starmade-accent/15 border-starmade-accent/40' : 'bg-black/20 border-white/5 hover:bg-white/5'}`}>
-      <input type="checkbox" checked={selected} onChange={onToggle} onClick={(e) => e.stopPropagation()} className="rounded border-gray-600 bg-gray-800 text-starmade-accent focus:ring-starmade-accent/50 flex-shrink-0" />
-      <div className="flex-1 min-w-0">
-        <div className="flex items-center gap-2">
-          <span className="text-sm font-medium text-white truncate">{bp.name}</span>
-          <span className={`text-[10px] font-bold uppercase tracking-wider px-1.5 py-0.5 rounded border ${colors}`}>{typeLabel(bp.type)}</span>
-          {bp.classification && <span className="text-[10px] uppercase tracking-wider text-gray-400">{bp.classification.replace(/_/g, ' ')}</span>}
-        </div>
-        <div className="flex items-center gap-3 mt-0.5 text-xs text-gray-500">
-          <span>{formatBytes(bp.sizeBytes)}</span>
-          {bp.elementCount != null && <span>{bp.elementCount.toLocaleString()} blocks</span>}
-          {bp.dockedCount > 0 && <span>{bp.dockedCount} docked</span>}
-        </div>
-      </div>
-    </button>
-  );
-};
+// ─── Row sub-component ──────────────────────────────────────────────────────
 
 const FileRow: React.FC<{ fileName: string; sizeBytes: number; selected: boolean; onToggle: () => void; onDragStart?: (e: React.DragEvent) => void }> = ({ fileName, sizeBytes, selected, onToggle, onDragStart }) => (
   <button draggable onDragStart={onDragStart} onClick={onToggle} className={`w-full text-left px-3 py-1.5 rounded-lg border transition-colors flex items-center gap-3 cursor-grab active:cursor-grabbing ${selected ? 'bg-starmade-accent/15 border-starmade-accent/40' : 'bg-black/20 border-white/5 hover:bg-white/5'}`}>
@@ -502,4 +383,4 @@ const FileRow: React.FC<{ fileName: string; sizeBytes: number; selected: boolean
   </button>
 );
 
-export default Blueprints;
+export default Templates;

--- a/components/pages/Templates/index.tsx
+++ b/components/pages/Templates/index.tsx
@@ -21,13 +21,6 @@ type CatalogItemRef = { kind: 'template'; fileName: string };
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
-const formatBytes = (v: number): string => {
-  if (v < 1024) return `${v} B`;
-  const kb = v / 1024;
-  if (kb < 1024) return `${kb.toFixed(1)} KB`;
-  return `${(kb / 1024).toFixed(2)} MB`;
-};
-
 const STORE_KEY = 'templatesCatalogPath';
 
 // ─── Component ──────────────────────────────────────────────────────────────
@@ -74,12 +67,12 @@ const Templates: React.FC = () => {
     [instances, selectedInstanceId],
   );
 
-  // ── Data loading ──────────────────────────────────────────────────────────
-  const loadCatalog = useCallback(async () => {
+  // ── Data loading (uses backend cache; Refresh buttons pass invalidate=true) ─
+  const loadCatalog = useCallback(async (invalidate = false) => {
     if (!catalogPath) return;
     setIsLoadingCatalog(true);
     try {
-      const data = await launcher.catalog.list(catalogPath);
+      const data = await launcher.catalog.list(catalogPath, invalidate);
       setCatalogData(data);
       if (data.error) setError(data.error);
     } catch (err) {
@@ -89,11 +82,11 @@ const Templates: React.FC = () => {
     }
   }, [launcher, catalogPath]);
 
-  const loadInstall = useCallback(async () => {
+  const loadInstall = useCallback(async (invalidate = false) => {
     if (!selectedInstance?.path) { setInstallData(null); return; }
     setIsLoadingInstall(true);
     try {
-      const data = await launcher.catalog.listInstallation(selectedInstance.path);
+      const data = await launcher.catalog.listInstallation(selectedInstance.path, invalidate);
       setInstallData(data);
     } catch (err) {
       setError(`Failed to load installation templates: ${String(err)}`);
@@ -309,7 +302,7 @@ const Templates: React.FC = () => {
                   <button onClick={handleDeleteSelected} disabled={isBusy || catalogSelection.size === 0} className="p-1.5 rounded-md hover:bg-red-500/20 transition-colors text-gray-400 hover:text-red-400 disabled:opacity-40" title="Delete selected">
                     <TrashIcon className="w-4 h-4" />
                   </button>
-                  <button onClick={() => void loadCatalog()} disabled={isLoadingCatalog} className="px-2 py-1 text-xs rounded bg-white/5 hover:bg-white/10 transition-colors text-gray-400">
+                  <button onClick={() => void loadCatalog(true)} disabled={isLoadingCatalog} className="px-2 py-1 text-xs rounded bg-white/5 hover:bg-white/10 transition-colors text-gray-400">
                     {isLoadingCatalog ? 'Loading...' : 'Refresh'}
                   </button>
                 </div>
@@ -319,7 +312,7 @@ const Templates: React.FC = () => {
                 {!isLoadingCatalog && catalogTemplates.length === 0 && (
                   <p className="text-gray-500 text-sm p-4 text-center">{searchQuery ? 'No matches.' : 'Catalog is empty. Import templates from an installation.'}</p>
                 )}
-                {catalogTemplates.map((tpl) => { const key = `tpl:${tpl.fileName}`; return <FileRow key={key} fileName={tpl.fileName} sizeBytes={tpl.sizeBytes} selected={catalogSelection.has(key)} onToggle={() => toggleCatalogItem(key)} onDragStart={(e) => handleDragStart(e, key, 'catalog')} />; })}
+                {catalogTemplates.map((tpl) => { const key = `tpl:${tpl.fileName}`; return <FileRow key={key} fileName={tpl.fileName} selected={catalogSelection.has(key)} onToggle={() => toggleCatalogItem(key)} onDragStart={(e) => handleDragStart(e, key, 'catalog')} />; })}
               </div>
             </div>
 
@@ -352,7 +345,7 @@ const Templates: React.FC = () => {
                   <button onClick={installSelection.size === allInstallKeys.length ? deselectAllInstall : selectAllInstall} className="px-2 py-1 text-xs rounded bg-white/5 hover:bg-white/10 transition-colors text-gray-400">
                     <CheckIcon className="w-3 h-3 inline mr-1" />{installSelection.size === allInstallKeys.length ? 'None' : 'All'}
                   </button>
-                  <button onClick={() => void loadInstall()} disabled={isLoadingInstall} className="px-2 py-1 text-xs rounded bg-white/5 hover:bg-white/10 transition-colors text-gray-400">
+                  <button onClick={() => void loadInstall(true)} disabled={isLoadingInstall} className="px-2 py-1 text-xs rounded bg-white/5 hover:bg-white/10 transition-colors text-gray-400">
                     {isLoadingInstall ? 'Loading...' : 'Refresh'}
                   </button>
                 </div>
@@ -363,7 +356,7 @@ const Templates: React.FC = () => {
                 {selectedInstance && !isLoadingInstall && installTemplates.length === 0 && (
                   <p className="text-gray-500 text-sm p-4 text-center">{searchQuery ? 'No matches.' : 'No templates in this installation.'}</p>
                 )}
-                {installTemplates.map((tpl) => { const key = `tpl:${tpl.fileName}`; return <FileRow key={key} fileName={tpl.fileName} sizeBytes={tpl.sizeBytes} selected={installSelection.has(key)} onToggle={() => toggleInstallItem(key)} onDragStart={(e) => handleDragStart(e, key, 'install')} />; })}
+                {installTemplates.map((tpl) => { const key = `tpl:${tpl.fileName}`; return <FileRow key={key} fileName={tpl.fileName} selected={installSelection.has(key)} onToggle={() => toggleInstallItem(key)} onDragStart={(e) => handleDragStart(e, key, 'install')} />; })}
               </div>
             </div>
           </div>
@@ -375,11 +368,10 @@ const Templates: React.FC = () => {
 
 // ─── Row sub-component ──────────────────────────────────────────────────────
 
-const FileRow: React.FC<{ fileName: string; sizeBytes: number; selected: boolean; onToggle: () => void; onDragStart?: (e: React.DragEvent) => void }> = ({ fileName, sizeBytes, selected, onToggle, onDragStart }) => (
+const FileRow: React.FC<{ fileName: string; selected: boolean; onToggle: () => void; onDragStart?: (e: React.DragEvent) => void }> = ({ fileName, selected, onToggle, onDragStart }) => (
   <button draggable onDragStart={onDragStart} onClick={onToggle} className={`w-full text-left px-3 py-1.5 rounded-lg border transition-colors flex items-center gap-3 cursor-grab active:cursor-grabbing ${selected ? 'bg-starmade-accent/15 border-starmade-accent/40' : 'bg-black/20 border-white/5 hover:bg-white/5'}`}>
     <input type="checkbox" checked={selected} onChange={onToggle} onClick={(e) => e.stopPropagation()} className="rounded border-gray-600 bg-gray-800 text-starmade-accent focus:ring-starmade-accent/50 flex-shrink-0" />
     <span className="text-sm text-gray-300 truncate flex-1">{fileName}</span>
-    <span className="text-xs text-gray-500 flex-shrink-0">{formatBytes(sizeBytes)}</span>
   </button>
 );
 

--- a/electron/blueprints.ts
+++ b/electron/blueprints.ts
@@ -465,3 +465,90 @@ function resolveItemSingle(root: string, item: CatalogItemRef): string {
 function itemLabel(item: CatalogItemRef): string {
   return item.kind === 'blueprint' ? item.name : ('fileName' in item ? item.fileName : '');
 }
+
+// ─── Sync Diff ───────────────────────────────────────────────────────────────
+
+export interface SyncDiffItem {
+  ref: CatalogItemRef;
+  label: string;
+  status: 'new' | 'modified' | 'up-to-date';
+  catalogModifiedMs: number;
+  installModifiedMs: number;
+}
+
+export interface SyncDiff {
+  items: SyncDiffItem[];
+  newCount: number;
+  modifiedCount: number;
+  upToDateCount: number;
+}
+
+/**
+ * Compare a catalog directory against an installation directory and return
+ * which items are new, modified (catalog is newer), or already up-to-date.
+ */
+export function computeSyncDiff(
+  catalogPath: string,
+  installPath: string,
+  kinds: Array<'blueprint' | 'exported' | 'template'>,
+): SyncDiff {
+  const items: SyncDiffItem[] = [];
+
+  if (kinds.includes('blueprint')) {
+    const catBlueprints = scanBlueprints(catalogPath);
+    const instBlueprints = scanBlueprints(installPath);
+    const instMap = new Map(instBlueprints.map((b) => [b.name, b]));
+    for (const bp of catBlueprints) {
+      const inst = instMap.get(bp.name);
+      const ref: CatalogItemRef = { kind: 'blueprint', name: bp.name };
+      if (!inst) {
+        items.push({ ref, label: bp.name, status: 'new', catalogModifiedMs: bp.modifiedMs, installModifiedMs: 0 });
+      } else if (bp.modifiedMs > inst.modifiedMs) {
+        items.push({ ref, label: bp.name, status: 'modified', catalogModifiedMs: bp.modifiedMs, installModifiedMs: inst.modifiedMs });
+      } else {
+        items.push({ ref, label: bp.name, status: 'up-to-date', catalogModifiedMs: bp.modifiedMs, installModifiedMs: inst.modifiedMs });
+      }
+    }
+  }
+
+  if (kinds.includes('exported')) {
+    const catExp = scanExported(catalogPath);
+    const instExp = scanExported(installPath);
+    const instMap = new Map(instExp.map((e) => [e.fileName, e]));
+    for (const exp of catExp) {
+      const inst = instMap.get(exp.fileName);
+      const ref: CatalogItemRef = { kind: 'exported', fileName: exp.fileName };
+      if (!inst) {
+        items.push({ ref, label: exp.fileName, status: 'new', catalogModifiedMs: exp.modifiedMs, installModifiedMs: 0 });
+      } else if (exp.modifiedMs > inst.modifiedMs) {
+        items.push({ ref, label: exp.fileName, status: 'modified', catalogModifiedMs: exp.modifiedMs, installModifiedMs: inst.modifiedMs });
+      } else {
+        items.push({ ref, label: exp.fileName, status: 'up-to-date', catalogModifiedMs: exp.modifiedMs, installModifiedMs: inst.modifiedMs });
+      }
+    }
+  }
+
+  if (kinds.includes('template')) {
+    const catTpl = scanTemplates(catalogPath);
+    const instTpl = scanTemplates(installPath);
+    const instMap = new Map(instTpl.map((t) => [t.fileName, t]));
+    for (const tpl of catTpl) {
+      const inst = instMap.get(tpl.fileName);
+      const ref: CatalogItemRef = { kind: 'template', fileName: tpl.fileName };
+      if (!inst) {
+        items.push({ ref, label: tpl.fileName, status: 'new', catalogModifiedMs: tpl.modifiedMs, installModifiedMs: 0 });
+      } else if (tpl.modifiedMs > inst.modifiedMs) {
+        items.push({ ref, label: tpl.fileName, status: 'modified', catalogModifiedMs: tpl.modifiedMs, installModifiedMs: inst.modifiedMs });
+      } else {
+        items.push({ ref, label: tpl.fileName, status: 'up-to-date', catalogModifiedMs: tpl.modifiedMs, installModifiedMs: inst.modifiedMs });
+      }
+    }
+  }
+
+  return {
+    items,
+    newCount: items.filter((i) => i.status === 'new').length,
+    modifiedCount: items.filter((i) => i.status === 'modified').length,
+    upToDateCount: items.filter((i) => i.status === 'up-to-date').length,
+  };
+}

--- a/electron/blueprints.ts
+++ b/electron/blueprints.ts
@@ -1,0 +1,467 @@
+import fs from 'fs';
+import path from 'path';
+import AdmZip from 'adm-zip';
+
+// ─── Types (mirroring types/index.ts — electron rootDir prevents cross-import) ─
+
+export type BlueprintEntityType = 'SHIP' | 'SPACE_STATION' | 'SHOP' | 'ASTEROID' | 'PLANET' | 'MANAGED_ASTEROID' | 'UNKNOWN';
+
+export interface BlueprintMeta {
+  name: string;
+  type: BlueprintEntityType;
+  classification?: string;
+  boundingBox?: { min: [number, number, number]; max: [number, number, number] };
+  elementCount?: number;
+  sizeBytes: number;
+  modifiedMs: number;
+  dockedCount: number;
+}
+
+export interface ExportedBlueprintMeta {
+  fileName: string;
+  sizeBytes: number;
+  modifiedMs: number;
+}
+
+export interface TemplateMeta {
+  fileName: string;
+  sizeBytes: number;
+  modifiedMs: number;
+}
+
+export interface CatalogListing {
+  catalogPath: string;
+  blueprints: BlueprintMeta[];
+  exported: ExportedBlueprintMeta[];
+  templates: TemplateMeta[];
+}
+
+export type CatalogItemRef =
+  | { kind: 'blueprint'; name: string }
+  | { kind: 'exported'; fileName: string }
+  | { kind: 'template'; fileName: string };
+
+export interface CatalogCopyResult {
+  success: boolean;
+  copiedCount?: number;
+  skippedCount?: number;
+  errors?: string[];
+}
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+const BLUEPRINTS_DIR = 'blueprints';
+const EXPORTED_DIR = path.join('blueprints', 'exported');
+const TEMPLATES_DIR = 'templates';
+const HEADER_FILE = 'header.smbph';
+
+/**
+ * BlueprintType enum ordinals from the StarMade source
+ * (org.schema.game.server.data.blueprintnw.BlueprintType).
+ */
+const BLUEPRINT_TYPE_BY_ORDINAL: BlueprintEntityType[] = [
+  'SHIP',             // 0
+  'SHOP',             // 1
+  'SPACE_STATION',    // 2
+  'MANAGED_ASTEROID', // 3
+  'ASTEROID',         // 4
+  'PLANET',           // 5
+];
+
+/**
+ * BlueprintClassification enum names from the StarMade source
+ * (org.schema.game.server.data.blueprintnw.BlueprintClassification).
+ */
+const CLASSIFICATION_BY_ORDINAL: string[] = [
+  'NONE', 'MINING', 'SUPPORT', 'CARGO', 'ATTACK', 'DEFENSE', 'CARRIER',
+  'SCOUT', 'SCAVENGER',
+  'NONE_STATION', 'SHIPYARD_STATION', 'OUTPOST_STATION', 'DEFENSE_STATION',
+  'MINING_STATION', 'FACTORY_STATION', 'TRADE_STATION', 'WAYPOINT_STATION',
+  'SHOPPING_STATION',
+  'NONE_ASTEROID', 'NONE_ASTEROID_MANAGED', 'NONE_PLANET', 'NONE_SHOP',
+  'NONE_ICO', 'ALL_SHIPS',
+];
+
+// ─── Header Parsing ──────────────────────────────────────────────────────────
+
+/**
+ * Parse a StarMade blueprint header (.smbph) file to extract metadata.
+ * This is a best-effort binary parser — returns partial data on failure.
+ */
+function parseBlueprintHeader(headerPath: string): {
+  type: BlueprintEntityType;
+  classification?: string;
+  boundingBox?: { min: [number, number, number]; max: [number, number, number] };
+  elementCount?: number;
+} {
+  const result: ReturnType<typeof parseBlueprintHeader> = { type: 'UNKNOWN' };
+  try {
+    const buf = fs.readFileSync(headerPath);
+    if (buf.length < 4) return result;
+
+    let offset = 0;
+
+    // int32: header version
+    const headerVersion = buf.readInt32BE(offset); offset += 4;
+
+    // version >= 5: UTF string (2-byte length prefix + chars)
+    if (headerVersion >= 5) {
+      if (offset + 2 > buf.length) return result;
+      const strLen = buf.readUInt16BE(offset); offset += 2;
+      offset += strLen; // skip the game version string
+    }
+
+    // int32: entity type ordinal
+    if (offset + 4 > buf.length) return result;
+    const typeOrdinal = buf.readInt32BE(offset); offset += 4;
+    result.type = BLUEPRINT_TYPE_BY_ORDINAL[typeOrdinal] ?? 'UNKNOWN';
+
+    // version >= 3 (and not version 0): int32 classification ordinal
+    if (headerVersion !== 0 && headerVersion >= 3) {
+      if (offset + 4 > buf.length) return result;
+      const classOrdinal = buf.readInt32BE(offset); offset += 4;
+      const classStr = CLASSIFICATION_BY_ORDINAL[classOrdinal];
+      if (classStr && classStr !== 'NONE' && classStr !== 'NONE_STATION'
+        && classStr !== 'NONE_ASTEROID' && classStr !== 'NONE_ASTEROID_MANAGED'
+        && classStr !== 'NONE_PLANET' && classStr !== 'NONE_SHOP'
+        && classStr !== 'NONE_ICO' && classStr !== 'ALL_SHIPS') {
+        result.classification = classStr;
+      }
+    }
+
+    // 6 floats: bounding box (minX, minY, minZ, maxX, maxY, maxZ)
+    if (offset + 24 > buf.length) return result;
+    const minX = buf.readFloatBE(offset); offset += 4;
+    const minY = buf.readFloatBE(offset); offset += 4;
+    const minZ = buf.readFloatBE(offset); offset += 4;
+    const maxX = buf.readFloatBE(offset); offset += 4;
+    const maxY = buf.readFloatBE(offset); offset += 4;
+    const maxZ = buf.readFloatBE(offset); offset += 4;
+    result.boundingBox = {
+      min: [minX, minY, minZ],
+      max: [maxX, maxY, maxZ],
+    };
+
+    // ElementCountMap: int32 entry count, then (short type + int count) per entry
+    if (offset + 4 > buf.length) return result;
+    const entryCount = buf.readInt32BE(offset); offset += 4;
+    let totalElements = 0;
+    for (let i = 0; i < entryCount; i++) {
+      if (offset + 6 > buf.length) break;
+      offset += 2; // skip short (block type id)
+      const count = buf.readInt32BE(offset); offset += 4;
+      totalElements += count;
+    }
+    result.elementCount = totalElements;
+  } catch {
+    // Best-effort: return whatever we managed to parse
+  }
+  return result;
+}
+
+// ─── Directory Size ──────────────────────────────────────────────────────────
+
+function dirSizeBytes(dirPath: string): number {
+  let total = 0;
+  try {
+    const entries = fs.readdirSync(dirPath, { withFileTypes: true });
+    for (const entry of entries) {
+      const full = path.join(dirPath, entry.name);
+      if (entry.isDirectory()) {
+        total += dirSizeBytes(full);
+      } else {
+        try { total += fs.statSync(full).size; } catch { /* skip */ }
+      }
+    }
+  } catch { /* skip */ }
+  return total;
+}
+
+// ─── Ensure Subdirectories ───────────────────────────────────────────────────
+
+function ensureCatalogDirs(catalogPath: string): void {
+  fs.mkdirSync(path.join(catalogPath, BLUEPRINTS_DIR), { recursive: true });
+  fs.mkdirSync(path.join(catalogPath, EXPORTED_DIR), { recursive: true });
+  fs.mkdirSync(path.join(catalogPath, TEMPLATES_DIR), { recursive: true });
+}
+
+// ─── List ────────────────────────────────────────────────────────────────────
+
+function scanBlueprints(rootPath: string): BlueprintMeta[] {
+  const bpDir = path.join(rootPath, BLUEPRINTS_DIR);
+  if (!fs.existsSync(bpDir)) return [];
+
+  const results: BlueprintMeta[] = [];
+  let entries: fs.Dirent[];
+  try { entries = fs.readdirSync(bpDir, { withFileTypes: true }); } catch { return []; }
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    // skip the exported/ and DATA/ subdirectories
+    if (entry.name === 'exported' || entry.name === 'DATA') continue;
+
+    const bpPath = path.join(bpDir, entry.name);
+    const headerPath = path.join(bpPath, HEADER_FILE);
+
+    let modifiedMs = 0;
+    try { modifiedMs = fs.statSync(headerPath).mtimeMs; } catch {
+      try { modifiedMs = fs.statSync(bpPath).mtimeMs; } catch { /* skip */ }
+    }
+
+    // Count ATTACHED_* child directories
+    let dockedCount = 0;
+    try {
+      const children = fs.readdirSync(bpPath, { withFileTypes: true });
+      for (const child of children) {
+        if (child.isDirectory() && child.name.startsWith('ATTACHED_')) {
+          dockedCount++;
+        }
+      }
+    } catch { /* skip */ }
+
+    const header = fs.existsSync(headerPath)
+      ? parseBlueprintHeader(headerPath)
+      : { type: 'UNKNOWN' as BlueprintEntityType };
+
+    results.push({
+      name: entry.name,
+      type: header.type,
+      classification: header.classification,
+      boundingBox: header.boundingBox,
+      elementCount: header.elementCount,
+      sizeBytes: dirSizeBytes(bpPath),
+      modifiedMs,
+      dockedCount,
+    });
+  }
+
+  results.sort((a, b) => a.name.localeCompare(b.name));
+  return results;
+}
+
+function scanExported(rootPath: string): ExportedBlueprintMeta[] {
+  const expDir = path.join(rootPath, EXPORTED_DIR);
+  if (!fs.existsSync(expDir)) return [];
+
+  const results: ExportedBlueprintMeta[] = [];
+  try {
+    const files = fs.readdirSync(expDir);
+    for (const file of files) {
+      if (!file.endsWith('.sment')) continue;
+      try {
+        const stat = fs.statSync(path.join(expDir, file));
+        results.push({ fileName: file, sizeBytes: stat.size, modifiedMs: stat.mtimeMs });
+      } catch { /* skip */ }
+    }
+  } catch { /* skip */ }
+
+  results.sort((a, b) => a.fileName.localeCompare(b.fileName));
+  return results;
+}
+
+function scanTemplates(rootPath: string): TemplateMeta[] {
+  const tplDir = path.join(rootPath, TEMPLATES_DIR);
+  if (!fs.existsSync(tplDir)) return [];
+
+  const results: TemplateMeta[] = [];
+  try {
+    const files = fs.readdirSync(tplDir);
+    for (const file of files) {
+      if (!file.endsWith('.smtpl')) continue;
+      try {
+        const stat = fs.statSync(path.join(tplDir, file));
+        results.push({ fileName: file, sizeBytes: stat.size, modifiedMs: stat.mtimeMs });
+      } catch { /* skip */ }
+    }
+  } catch { /* skip */ }
+
+  results.sort((a, b) => a.fileName.localeCompare(b.fileName));
+  return results;
+}
+
+/** List all items in the central catalog directory. */
+export function listCatalog(catalogPath: string): CatalogListing {
+  ensureCatalogDirs(catalogPath);
+  return {
+    catalogPath,
+    blueprints: scanBlueprints(catalogPath),
+    exported: scanExported(catalogPath),
+    templates: scanTemplates(catalogPath),
+  };
+}
+
+/** List blueprints/templates in a specific installation directory. */
+export function listInstallationBlueprints(installPath: string): CatalogListing {
+  return {
+    catalogPath: installPath,
+    blueprints: scanBlueprints(installPath),
+    exported: scanExported(installPath),
+    templates: scanTemplates(installPath),
+  };
+}
+
+// ─── Deploy (Catalog → Installation) ────────────────────────────────────────
+
+export function deployToInstallations(
+  catalogPath: string,
+  items: CatalogItemRef[],
+  targetPaths: string[],
+  overwrite: boolean,
+): CatalogCopyResult {
+  let copiedCount = 0;
+  let skippedCount = 0;
+  const errors: string[] = [];
+
+  for (const target of targetPaths) {
+    for (const item of items) {
+      try {
+        const { src, dst } = resolveItemPaths(catalogPath, target, item);
+        if (fs.existsSync(dst) && !overwrite) {
+          skippedCount++;
+          continue;
+        }
+        if (item.kind === 'blueprint') {
+          fs.mkdirSync(path.dirname(dst), { recursive: true });
+          fs.cpSync(src, dst, { recursive: true, force: true });
+        } else {
+          fs.mkdirSync(path.dirname(dst), { recursive: true });
+          fs.copyFileSync(src, dst);
+        }
+        copiedCount++;
+      } catch (err) {
+        errors.push(`Failed to deploy ${itemLabel(item)} to ${target}: ${String(err)}`);
+      }
+    }
+  }
+
+  return { success: errors.length === 0, copiedCount, skippedCount, errors: errors.length ? errors : undefined };
+}
+
+// ─── Import (Installation → Catalog) ────────────────────────────────────────
+
+export function importToCatalog(
+  installPath: string,
+  items: CatalogItemRef[],
+  catalogPath: string,
+  overwrite: boolean,
+): CatalogCopyResult {
+  ensureCatalogDirs(catalogPath);
+  let copiedCount = 0;
+  let skippedCount = 0;
+  const errors: string[] = [];
+
+  for (const item of items) {
+    try {
+      const { src, dst } = resolveItemPaths(installPath, catalogPath, item);
+      if (fs.existsSync(dst) && !overwrite) {
+        skippedCount++;
+        continue;
+      }
+      if (item.kind === 'blueprint') {
+        fs.mkdirSync(path.dirname(dst), { recursive: true });
+        fs.cpSync(src, dst, { recursive: true, force: true });
+      } else {
+        fs.mkdirSync(path.dirname(dst), { recursive: true });
+        fs.copyFileSync(src, dst);
+      }
+      copiedCount++;
+    } catch (err) {
+      errors.push(`Failed to import ${itemLabel(item)}: ${String(err)}`);
+    }
+  }
+
+  return { success: errors.length === 0, copiedCount, skippedCount, errors: errors.length ? errors : undefined };
+}
+
+// ─── Delete ──────────────────────────────────────────────────────────────────
+
+export function deleteCatalogItem(
+  catalogPath: string,
+  item: CatalogItemRef,
+): { success: boolean; error?: string } {
+  try {
+    const itemPath = resolveItemSingle(catalogPath, item);
+    if (!fs.existsSync(itemPath)) return { success: true }; // already gone
+    if (item.kind === 'blueprint') {
+      fs.rmSync(itemPath, { recursive: true, force: true });
+    } else {
+      fs.unlinkSync(itemPath);
+    }
+    return { success: true };
+  } catch (err) {
+    return { success: false, error: String(err) };
+  }
+}
+
+// ─── Import .sment ───────────────────────────────────────────────────────────
+
+export function importSmentToCatalog(
+  catalogPath: string,
+  smentFilePath: string,
+): CatalogCopyResult {
+  ensureCatalogDirs(catalogPath);
+  const errors: string[] = [];
+  let copiedCount = 0;
+
+  const baseName = path.basename(smentFilePath, '.sment');
+  const bpDest = path.join(catalogPath, BLUEPRINTS_DIR, baseName);
+  const expDest = path.join(catalogPath, EXPORTED_DIR, path.basename(smentFilePath));
+
+  // Extract the .sment (ZIP) into blueprints/<name>/
+  try {
+    fs.mkdirSync(bpDest, { recursive: true });
+    const zip = new AdmZip(smentFilePath);
+    zip.extractAllTo(bpDest, true);
+    copiedCount++;
+  } catch (err) {
+    errors.push(`Failed to extract ${smentFilePath}: ${String(err)}`);
+  }
+
+  // Copy the .sment archive to exported/
+  try {
+    fs.copyFileSync(smentFilePath, expDest);
+    copiedCount++;
+  } catch (err) {
+    errors.push(`Failed to copy .sment to exported/: ${String(err)}`);
+  }
+
+  return { success: errors.length === 0, copiedCount, errors: errors.length ? errors : undefined };
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function resolveItemPaths(
+  srcRoot: string,
+  dstRoot: string,
+  item: CatalogItemRef,
+): { src: string; dst: string } {
+  switch (item.kind) {
+    case 'blueprint':
+      return {
+        src: path.join(srcRoot, BLUEPRINTS_DIR, item.name),
+        dst: path.join(dstRoot, BLUEPRINTS_DIR, item.name),
+      };
+    case 'exported':
+      return {
+        src: path.join(srcRoot, EXPORTED_DIR, item.fileName),
+        dst: path.join(dstRoot, EXPORTED_DIR, item.fileName),
+      };
+    case 'template':
+      return {
+        src: path.join(srcRoot, TEMPLATES_DIR, item.fileName),
+        dst: path.join(dstRoot, TEMPLATES_DIR, item.fileName),
+      };
+  }
+}
+
+function resolveItemSingle(root: string, item: CatalogItemRef): string {
+  switch (item.kind) {
+    case 'blueprint': return path.join(root, BLUEPRINTS_DIR, item.name);
+    case 'exported': return path.join(root, EXPORTED_DIR, item.fileName);
+    case 'template': return path.join(root, TEMPLATES_DIR, item.fileName);
+  }
+}
+
+function itemLabel(item: CatalogItemRef): string {
+  return item.kind === 'blueprint' ? item.name : ('fileName' in item ? item.fileName : '');
+}

--- a/electron/blueprints.ts
+++ b/electron/blueprints.ts
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import fsp from 'fs/promises';
 import path from 'path';
 import AdmZip from 'adm-zip';
 
@@ -159,145 +160,155 @@ function parseBlueprintHeader(headerPath: string): {
   return result;
 }
 
-// ─── Directory Size ──────────────────────────────────────────────────────────
-
-function dirSizeBytes(dirPath: string): number {
-  let total = 0;
-  try {
-    const entries = fs.readdirSync(dirPath, { withFileTypes: true });
-    for (const entry of entries) {
-      const full = path.join(dirPath, entry.name);
-      if (entry.isDirectory()) {
-        total += dirSizeBytes(full);
-      } else {
-        try { total += fs.statSync(full).size; } catch { /* skip */ }
-      }
-    }
-  } catch { /* skip */ }
-  return total;
-}
-
 // ─── Ensure Subdirectories ───────────────────────────────────────────────────
 
-function ensureCatalogDirs(catalogPath: string): void {
-  fs.mkdirSync(path.join(catalogPath, BLUEPRINTS_DIR), { recursive: true });
-  fs.mkdirSync(path.join(catalogPath, EXPORTED_DIR), { recursive: true });
-  fs.mkdirSync(path.join(catalogPath, TEMPLATES_DIR), { recursive: true });
+async function ensureCatalogDirs(catalogPath: string): Promise<void> {
+  await fsp.mkdir(path.join(catalogPath, BLUEPRINTS_DIR), { recursive: true });
+  await fsp.mkdir(path.join(catalogPath, EXPORTED_DIR), { recursive: true });
+  await fsp.mkdir(path.join(catalogPath, TEMPLATES_DIR), { recursive: true });
 }
 
-// ─── List ────────────────────────────────────────────────────────────────────
+// ─── Cache ───────────────────────────────────────────────────────────────────
+// In-memory cache keyed by directory path. Invalidated after mutations or when
+// the caller passes `invalidate: true`.
 
-function scanBlueprints(rootPath: string): BlueprintMeta[] {
-  const bpDir = path.join(rootPath, BLUEPRINTS_DIR);
-  if (!fs.existsSync(bpDir)) return [];
+interface CachedListing { listing: CatalogListing; cachedAt: number; }
+const listingCache = new Map<string, CachedListing>();
+const CACHE_TTL_MS = 30_000; // 30 seconds
 
-  const results: BlueprintMeta[] = [];
-  let entries: fs.Dirent[];
-  try { entries = fs.readdirSync(bpDir, { withFileTypes: true }); } catch { return []; }
+export function invalidateCatalogCache(dirPath?: string): void {
+  if (dirPath) { listingCache.delete(dirPath); } else { listingCache.clear(); }
+}
 
-  for (const entry of entries) {
-    if (!entry.isDirectory()) continue;
-    // skip the exported/ and DATA/ subdirectories
-    if (entry.name === 'exported' || entry.name === 'DATA') continue;
+// ─── Async scanning ─────────────────────────────────────────────────────────
 
-    const bpPath = path.join(bpDir, entry.name);
-    const headerPath = path.join(bpPath, HEADER_FILE);
+async function scanBlueprintEntry(bpPath: string, name: string): Promise<BlueprintMeta> {
+  const headerPath = path.join(bpPath, HEADER_FILE);
 
-    let modifiedMs = 0;
-    try { modifiedMs = fs.statSync(headerPath).mtimeMs; } catch {
-      try { modifiedMs = fs.statSync(bpPath).mtimeMs; } catch { /* skip */ }
-    }
-
-    // Count ATTACHED_* child directories
-    let dockedCount = 0;
-    try {
-      const children = fs.readdirSync(bpPath, { withFileTypes: true });
-      for (const child of children) {
-        if (child.isDirectory() && child.name.startsWith('ATTACHED_')) {
-          dockedCount++;
-        }
-      }
-    } catch { /* skip */ }
-
-    const header = fs.existsSync(headerPath)
-      ? parseBlueprintHeader(headerPath)
-      : { type: 'UNKNOWN' as BlueprintEntityType };
-
-    results.push({
-      name: entry.name,
-      type: header.type,
-      classification: header.classification,
-      boundingBox: header.boundingBox,
-      elementCount: header.elementCount,
-      sizeBytes: dirSizeBytes(bpPath),
-      modifiedMs,
-      dockedCount,
-    });
+  // Stat header (or directory) for modifiedMs — skip expensive recursive size calc
+  let modifiedMs = 0;
+  let sizeBytes = 0;
+  try {
+    const st = await fsp.stat(headerPath);
+    modifiedMs = st.mtimeMs;
+    sizeBytes = st.size;
+  } catch {
+    try { modifiedMs = (await fsp.stat(bpPath)).mtimeMs; } catch { /* skip */ }
   }
+
+  // Count ATTACHED_* child directories
+  let dockedCount = 0;
+  try {
+    const children = await fsp.readdir(bpPath, { withFileTypes: true });
+    for (const child of children) {
+      if (child.isDirectory() && child.name.startsWith('ATTACHED_')) dockedCount++;
+    }
+  } catch { /* skip */ }
+
+  // Parse header (sync but only reads first ~100 bytes — cheap)
+  let header: ReturnType<typeof parseBlueprintHeader> = { type: 'UNKNOWN' };
+  try {
+    await fsp.access(headerPath);
+    header = parseBlueprintHeader(headerPath);
+  } catch { /* no header */ }
+
+  return {
+    name,
+    type: header.type,
+    classification: header.classification,
+    boundingBox: header.boundingBox,
+    elementCount: header.elementCount,
+    sizeBytes,
+    modifiedMs,
+    dockedCount,
+  };
+}
+
+async function scanBlueprints(rootPath: string): Promise<BlueprintMeta[]> {
+  const bpDir = path.join(rootPath, BLUEPRINTS_DIR);
+  let entries: fs.Dirent[];
+  try { entries = await fsp.readdir(bpDir, { withFileTypes: true }); } catch { return []; }
+
+  const dirs = entries.filter(
+    (e) => e.isDirectory() && e.name !== 'exported' && e.name !== 'DATA' && !e.name.startsWith('._'),
+  );
+
+  // Parse all blueprints in parallel (I/O bound, not CPU bound)
+  const results = await Promise.all(
+    dirs.map((d) => scanBlueprintEntry(path.join(bpDir, d.name), d.name)),
+  );
 
   results.sort((a, b) => a.name.localeCompare(b.name));
   return results;
 }
 
-function scanExported(rootPath: string): ExportedBlueprintMeta[] {
+async function scanExported(rootPath: string): Promise<ExportedBlueprintMeta[]> {
   const expDir = path.join(rootPath, EXPORTED_DIR);
-  if (!fs.existsSync(expDir)) return [];
+  let files: string[];
+  try { files = await fsp.readdir(expDir); } catch { return []; }
 
   const results: ExportedBlueprintMeta[] = [];
-  try {
-    const files = fs.readdirSync(expDir);
-    for (const file of files) {
-      if (!file.endsWith('.sment')) continue;
-      try {
-        const stat = fs.statSync(path.join(expDir, file));
-        results.push({ fileName: file, sizeBytes: stat.size, modifiedMs: stat.mtimeMs });
-      } catch { /* skip */ }
-    }
-  } catch { /* skip */ }
+  await Promise.all(files.filter((f) => f.endsWith('.sment') && !f.startsWith('._')).map(async (file) => {
+    try {
+      const stat = await fsp.stat(path.join(expDir, file));
+      results.push({ fileName: file, sizeBytes: stat.size, modifiedMs: stat.mtimeMs });
+    } catch { /* skip */ }
+  }));
 
   results.sort((a, b) => a.fileName.localeCompare(b.fileName));
   return results;
 }
 
-function scanTemplates(rootPath: string): TemplateMeta[] {
+async function scanTemplates(rootPath: string): Promise<TemplateMeta[]> {
   const tplDir = path.join(rootPath, TEMPLATES_DIR);
-  if (!fs.existsSync(tplDir)) return [];
+  let files: string[];
+  try { files = await fsp.readdir(tplDir); } catch { return []; }
 
   const results: TemplateMeta[] = [];
-  try {
-    const files = fs.readdirSync(tplDir);
-    for (const file of files) {
-      if (!file.endsWith('.smtpl')) continue;
-      try {
-        const stat = fs.statSync(path.join(tplDir, file));
-        results.push({ fileName: file, sizeBytes: stat.size, modifiedMs: stat.mtimeMs });
-      } catch { /* skip */ }
-    }
-  } catch { /* skip */ }
+  await Promise.all(files.filter((f) => f.endsWith('.smtpl') && !f.startsWith('._')).map(async (file) => {
+    try {
+      const stat = await fsp.stat(path.join(tplDir, file));
+      results.push({ fileName: file, sizeBytes: stat.size, modifiedMs: stat.mtimeMs });
+    } catch { /* skip */ }
+  }));
 
   results.sort((a, b) => a.fileName.localeCompare(b.fileName));
   return results;
 }
 
-/** List all items in the central catalog directory. */
-export function listCatalog(catalogPath: string): CatalogListing {
-  ensureCatalogDirs(catalogPath);
-  return {
-    catalogPath,
-    blueprints: scanBlueprints(catalogPath),
-    exported: scanExported(catalogPath),
-    templates: scanTemplates(catalogPath),
-  };
+/** List all items in a catalog directory (cached). */
+export async function listCatalog(catalogPath: string, invalidate = false): Promise<CatalogListing> {
+  if (!invalidate) {
+    const cached = listingCache.get(catalogPath);
+    if (cached && Date.now() - cached.cachedAt < CACHE_TTL_MS) return cached.listing;
+  }
+
+  await ensureCatalogDirs(catalogPath);
+  const [blueprints, exported, templates] = await Promise.all([
+    scanBlueprints(catalogPath),
+    scanExported(catalogPath),
+    scanTemplates(catalogPath),
+  ]);
+  const listing: CatalogListing = { catalogPath, blueprints, exported, templates };
+  listingCache.set(catalogPath, { listing, cachedAt: Date.now() });
+  return listing;
 }
 
-/** List blueprints/templates in a specific installation directory. */
-export function listInstallationBlueprints(installPath: string): CatalogListing {
-  return {
-    catalogPath: installPath,
-    blueprints: scanBlueprints(installPath),
-    exported: scanExported(installPath),
-    templates: scanTemplates(installPath),
-  };
+/** List blueprints/templates in a specific installation directory (cached). */
+export async function listInstallationBlueprints(installPath: string, invalidate = false): Promise<CatalogListing> {
+  if (!invalidate) {
+    const cached = listingCache.get(installPath);
+    if (cached && Date.now() - cached.cachedAt < CACHE_TTL_MS) return cached.listing;
+  }
+
+  const [blueprints, exported, templates] = await Promise.all([
+    scanBlueprints(installPath),
+    scanExported(installPath),
+    scanTemplates(installPath),
+  ]);
+  const listing: CatalogListing = { catalogPath: installPath, blueprints, exported, templates };
+  listingCache.set(installPath, { listing, cachedAt: Date.now() });
+  return listing;
 }
 
 // ─── Deploy (Catalog → Installation) ────────────────────────────────────────
@@ -332,6 +343,7 @@ export function deployToInstallations(
         errors.push(`Failed to deploy ${itemLabel(item)} to ${target}: ${String(err)}`);
       }
     }
+    invalidateCatalogCache(target);
   }
 
   return { success: errors.length === 0, copiedCount, skippedCount, errors: errors.length ? errors : undefined };
@@ -345,7 +357,9 @@ export function importToCatalog(
   catalogPath: string,
   overwrite: boolean,
 ): CatalogCopyResult {
-  ensureCatalogDirs(catalogPath);
+  fs.mkdirSync(path.join(catalogPath, BLUEPRINTS_DIR), { recursive: true });
+  fs.mkdirSync(path.join(catalogPath, EXPORTED_DIR), { recursive: true });
+  fs.mkdirSync(path.join(catalogPath, TEMPLATES_DIR), { recursive: true });
   let copiedCount = 0;
   let skippedCount = 0;
   const errors: string[] = [];
@@ -370,6 +384,7 @@ export function importToCatalog(
     }
   }
 
+  invalidateCatalogCache(catalogPath);
   return { success: errors.length === 0, copiedCount, skippedCount, errors: errors.length ? errors : undefined };
 }
 
@@ -381,12 +396,13 @@ export function deleteCatalogItem(
 ): { success: boolean; error?: string } {
   try {
     const itemPath = resolveItemSingle(catalogPath, item);
-    if (!fs.existsSync(itemPath)) return { success: true }; // already gone
+    if (!fs.existsSync(itemPath)) return { success: true };
     if (item.kind === 'blueprint') {
       fs.rmSync(itemPath, { recursive: true, force: true });
     } else {
       fs.unlinkSync(itemPath);
     }
+    invalidateCatalogCache(catalogPath);
     return { success: true };
   } catch (err) {
     return { success: false, error: String(err) };
@@ -399,7 +415,8 @@ export function importSmentToCatalog(
   catalogPath: string,
   smentFilePath: string,
 ): CatalogCopyResult {
-  ensureCatalogDirs(catalogPath);
+  fs.mkdirSync(path.join(catalogPath, BLUEPRINTS_DIR), { recursive: true });
+  fs.mkdirSync(path.join(catalogPath, EXPORTED_DIR), { recursive: true });
   const errors: string[] = [];
   let copiedCount = 0;
 
@@ -407,7 +424,6 @@ export function importSmentToCatalog(
   const bpDest = path.join(catalogPath, BLUEPRINTS_DIR, baseName);
   const expDest = path.join(catalogPath, EXPORTED_DIR, path.basename(smentFilePath));
 
-  // Extract the .sment (ZIP) into blueprints/<name>/
   try {
     fs.mkdirSync(bpDest, { recursive: true });
     const zip = new AdmZip(smentFilePath);
@@ -417,7 +433,6 @@ export function importSmentToCatalog(
     errors.push(`Failed to extract ${smentFilePath}: ${String(err)}`);
   }
 
-  // Copy the .sment archive to exported/
   try {
     fs.copyFileSync(smentFilePath, expDest);
     copiedCount++;
@@ -425,6 +440,7 @@ export function importSmentToCatalog(
     errors.push(`Failed to copy .sment to exported/: ${String(err)}`);
   }
 
+  invalidateCatalogCache(catalogPath);
   return { success: errors.length === 0, copiedCount, errors: errors.length ? errors : undefined };
 }
 
@@ -487,16 +503,17 @@ export interface SyncDiff {
  * Compare a catalog directory against an installation directory and return
  * which items are new, modified (catalog is newer), or already up-to-date.
  */
-export function computeSyncDiff(
+export async function computeSyncDiff(
   catalogPath: string,
   installPath: string,
   kinds: Array<'blueprint' | 'exported' | 'template'>,
-): SyncDiff {
+): Promise<SyncDiff> {
   const items: SyncDiffItem[] = [];
 
   if (kinds.includes('blueprint')) {
-    const catBlueprints = scanBlueprints(catalogPath);
-    const instBlueprints = scanBlueprints(installPath);
+    const [catBlueprints, instBlueprints] = await Promise.all([
+      scanBlueprints(catalogPath), scanBlueprints(installPath),
+    ]);
     const instMap = new Map(instBlueprints.map((b) => [b.name, b]));
     for (const bp of catBlueprints) {
       const inst = instMap.get(bp.name);
@@ -512,8 +529,9 @@ export function computeSyncDiff(
   }
 
   if (kinds.includes('exported')) {
-    const catExp = scanExported(catalogPath);
-    const instExp = scanExported(installPath);
+    const [catExp, instExp] = await Promise.all([
+      scanExported(catalogPath), scanExported(installPath),
+    ]);
     const instMap = new Map(instExp.map((e) => [e.fileName, e]));
     for (const exp of catExp) {
       const inst = instMap.get(exp.fileName);
@@ -529,8 +547,9 @@ export function computeSyncDiff(
   }
 
   if (kinds.includes('template')) {
-    const catTpl = scanTemplates(catalogPath);
-    const instTpl = scanTemplates(installPath);
+    const [catTpl, instTpl] = await Promise.all([
+      scanTemplates(catalogPath), scanTemplates(installPath),
+    ]);
     const instMap = new Map(instTpl.map((t) => [t.fileName, t]));
     for (const tpl of catTpl) {
       const inst = instMap.get(tpl.fileName);

--- a/electron/ipc-channels.ts
+++ b/electron/ipc-channels.ts
@@ -256,6 +256,21 @@ export const IPC = {
   /** Renderer → Main (invoke): import modpack manifest and download listed mods. */
   MODS_IMPORT_MODPACK: 'mods:import-modpack',
 
+  // ─── Blueprint Catalog ──────────────────────────────────────────────────────
+
+  /** Renderer → Main (invoke): list all blueprints, exported archives, and templates in the catalog directory. */
+  CATALOG_LIST: 'catalog:list',
+  /** Renderer → Main (invoke): list blueprints/templates in a specific installation's directory. */
+  CATALOG_LIST_INSTALLATION: 'catalog:list-installation',
+  /** Renderer → Main (invoke): copy items from catalog to one or more installations. */
+  CATALOG_DEPLOY: 'catalog:deploy',
+  /** Renderer → Main (invoke): import items from an installation into the catalog. */
+  CATALOG_IMPORT: 'catalog:import',
+  /** Renderer → Main (invoke): delete a blueprint, exported archive, or template from the catalog. */
+  CATALOG_DELETE: 'catalog:delete',
+  /** Renderer → Main (invoke): import a .sment file into the catalog (extracts ZIP + copies archive). */
+  CATALOG_IMPORT_SMENT: 'catalog:import-sment',
+
   // ─── Legacy installation detection ──────────────────────────────────────────
 
   /** Renderer → Main (invoke): scan current and sub-directories for legacy StarMade installs (StarMade.jar). */

--- a/electron/ipc-channels.ts
+++ b/electron/ipc-channels.ts
@@ -256,20 +256,24 @@ export const IPC = {
   /** Renderer → Main (invoke): import modpack manifest and download listed mods. */
   MODS_IMPORT_MODPACK: 'mods:import-modpack',
 
-  // ─── Blueprint Catalog ──────────────────────────────────────────────────────
+  // ─── Blueprint / Template Catalog ───────────────────────────────────────────
 
-  /** Renderer → Main (invoke): list all blueprints, exported archives, and templates in the catalog directory. */
+  /** Renderer → Main (invoke): list blueprints, exported archives, and templates in the given catalog directory. */
   CATALOG_LIST: 'catalog:list',
   /** Renderer → Main (invoke): list blueprints/templates in a specific installation's directory. */
   CATALOG_LIST_INSTALLATION: 'catalog:list-installation',
-  /** Renderer → Main (invoke): copy items from catalog to one or more installations. */
+  /** Renderer → Main (invoke): copy items from a catalog directory to one or more installations. */
   CATALOG_DEPLOY: 'catalog:deploy',
-  /** Renderer → Main (invoke): import items from an installation into the catalog. */
+  /** Renderer → Main (invoke): import items from an installation into a catalog directory. */
   CATALOG_IMPORT: 'catalog:import',
-  /** Renderer → Main (invoke): delete a blueprint, exported archive, or template from the catalog. */
+  /** Renderer → Main (invoke): delete a blueprint, exported archive, or template from a catalog directory. */
   CATALOG_DELETE: 'catalog:delete',
-  /** Renderer → Main (invoke): import a .sment file into the catalog (extracts ZIP + copies archive). */
+  /** Renderer → Main (invoke): import a .sment file into the blueprints catalog (extracts ZIP + copies archive). */
   CATALOG_IMPORT_SMENT: 'catalog:import-sment',
+  /** Renderer → Main (invoke): compute sync diff between catalog and installation (items added/removed/modified). */
+  CATALOG_SYNC_DIFF: 'catalog:sync-diff',
+  /** Renderer → Main (invoke): apply a sync from catalog to installation (deploy all, skip conflicts unless overwrite). */
+  CATALOG_SYNC_APPLY: 'catalog:sync-apply',
 
   // ─── Legacy installation detection ──────────────────────────────────────────
 

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -45,6 +45,7 @@ import {
   importToCatalog,
   deleteCatalogItem,
   importSmentToCatalog,
+  computeSyncDiff,
 } from './blueprints.js';
 import type { CatalogItemRef } from './blueprints.js';
 import { getManagedPathCandidates } from './install-paths.js';
@@ -2503,10 +2504,12 @@ ipcMain.handle(IPC.MODS_IMPORT_MODPACK, async (_event, installationPath: string,
   }
 });
 
-// ─── Blueprint Catalog handlers ─────────────────────────────────────────────
+// ─── Blueprint / Template Catalog handlers ──────────────────────────────────
+// All handlers accept an explicit catalogPath from the renderer so the same
+// IPC surface serves both the Blueprints page (blueprintsCatalogPath) and the
+// Templates page (templatesCatalogPath).
 
-ipcMain.handle(IPC.CATALOG_LIST, () => {
-  const catalogPath = storeGet('catalogPath') as string | undefined;
+ipcMain.handle(IPC.CATALOG_LIST, (_event, catalogPath: string) => {
   if (!catalogPath) return { catalogPath: '', blueprints: [], exported: [], templates: [] };
   try {
     return listCatalog(catalogPath);
@@ -2525,8 +2528,7 @@ ipcMain.handle(IPC.CATALOG_LIST_INSTALLATION, (_event, installationPath: string)
 
 ipcMain.handle(
   IPC.CATALOG_DEPLOY,
-  (_event, items: CatalogItemRef[], targetPaths: string[], overwrite?: boolean) => {
-    const catalogPath = storeGet('catalogPath') as string | undefined;
+  (_event, catalogPath: string, items: CatalogItemRef[], targetPaths: string[], overwrite?: boolean) => {
     if (!catalogPath) return { success: false, errors: ['No catalog path configured.'] };
     try {
       return deployToInstallations(catalogPath, items, targetPaths, overwrite ?? false);
@@ -2538,8 +2540,7 @@ ipcMain.handle(
 
 ipcMain.handle(
   IPC.CATALOG_IMPORT,
-  (_event, installationPath: string, items: CatalogItemRef[], overwrite?: boolean) => {
-    const catalogPath = storeGet('catalogPath') as string | undefined;
+  (_event, catalogPath: string, installationPath: string, items: CatalogItemRef[], overwrite?: boolean) => {
     if (!catalogPath) return { success: false, errors: ['No catalog path configured.'] };
     try {
       return importToCatalog(installationPath, items, catalogPath, overwrite ?? false);
@@ -2549,8 +2550,7 @@ ipcMain.handle(
   },
 );
 
-ipcMain.handle(IPC.CATALOG_DELETE, (_event, item: CatalogItemRef) => {
-  const catalogPath = storeGet('catalogPath') as string | undefined;
+ipcMain.handle(IPC.CATALOG_DELETE, (_event, catalogPath: string, item: CatalogItemRef) => {
   if (!catalogPath) return { success: false, error: 'No catalog path configured.' };
   try {
     return deleteCatalogItem(catalogPath, item);
@@ -2559,8 +2559,7 @@ ipcMain.handle(IPC.CATALOG_DELETE, (_event, item: CatalogItemRef) => {
   }
 });
 
-ipcMain.handle(IPC.CATALOG_IMPORT_SMENT, (_event, smentPath: string) => {
-  const catalogPath = storeGet('catalogPath') as string | undefined;
+ipcMain.handle(IPC.CATALOG_IMPORT_SMENT, (_event, catalogPath: string, smentPath: string) => {
   if (!catalogPath) return { success: false, errors: ['No catalog path configured.'] };
   try {
     return importSmentToCatalog(catalogPath, smentPath);
@@ -2568,6 +2567,30 @@ ipcMain.handle(IPC.CATALOG_IMPORT_SMENT, (_event, smentPath: string) => {
     return { success: false, errors: [String(error)] };
   }
 });
+
+ipcMain.handle(
+  IPC.CATALOG_SYNC_DIFF,
+  (_event, catalogPath: string, installationPath: string, kinds: Array<'blueprint' | 'exported' | 'template'>) => {
+    if (!catalogPath) return { items: [], newCount: 0, modifiedCount: 0, upToDateCount: 0 };
+    try {
+      return computeSyncDiff(catalogPath, installationPath, kinds);
+    } catch (error) {
+      return { items: [], newCount: 0, modifiedCount: 0, upToDateCount: 0, error: String(error) };
+    }
+  },
+);
+
+ipcMain.handle(
+  IPC.CATALOG_SYNC_APPLY,
+  (_event, catalogPath: string, items: CatalogItemRef[], targetPath: string, overwrite?: boolean) => {
+    if (!catalogPath) return { success: false, errors: ['No catalog path configured.'] };
+    try {
+      return deployToInstallations(catalogPath, items, [targetPath], overwrite ?? false);
+    } catch (error) {
+      return { success: false, errors: [String(error)] };
+    }
+  },
+);
 
 // ─── Preset assets initialisation ───────────────────────────────────────────
 

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -38,6 +38,15 @@ import { isRunningOnWayland } from './wayland-detect.js';
 import { isRunningAsAppImage } from './appimage-detect.js';
 import { registerAppImageDesktopIntegration } from './desktop-integration.js';
 import { parseVersionTxt } from './legacy.js';
+import {
+  listCatalog,
+  listInstallationBlueprints,
+  deployToInstallations,
+  importToCatalog,
+  deleteCatalogItem,
+  importSmentToCatalog,
+} from './blueprints.js';
+import type { CatalogItemRef } from './blueprints.js';
 import { getManagedPathCandidates } from './install-paths.js';
 import { registerRemoteIpcHandlers } from './starmote-ipc.js';
 import { isStarmoteRolloutEnabled } from './starmote-feature-flag.js';
@@ -2491,6 +2500,72 @@ ipcMain.handle(IPC.MODS_IMPORT_MODPACK, async (_event, installationPath: string,
     };
   } catch (error) {
     return { success: false, error: String(error) };
+  }
+});
+
+// ─── Blueprint Catalog handlers ─────────────────────────────────────────────
+
+ipcMain.handle(IPC.CATALOG_LIST, () => {
+  const catalogPath = storeGet('catalogPath') as string | undefined;
+  if (!catalogPath) return { catalogPath: '', blueprints: [], exported: [], templates: [] };
+  try {
+    return listCatalog(catalogPath);
+  } catch (error) {
+    return { catalogPath, blueprints: [], exported: [], templates: [], error: String(error) };
+  }
+});
+
+ipcMain.handle(IPC.CATALOG_LIST_INSTALLATION, (_event, installationPath: string) => {
+  try {
+    return listInstallationBlueprints(installationPath);
+  } catch (error) {
+    return { catalogPath: installationPath, blueprints: [], exported: [], templates: [], error: String(error) };
+  }
+});
+
+ipcMain.handle(
+  IPC.CATALOG_DEPLOY,
+  (_event, items: CatalogItemRef[], targetPaths: string[], overwrite?: boolean) => {
+    const catalogPath = storeGet('catalogPath') as string | undefined;
+    if (!catalogPath) return { success: false, errors: ['No catalog path configured.'] };
+    try {
+      return deployToInstallations(catalogPath, items, targetPaths, overwrite ?? false);
+    } catch (error) {
+      return { success: false, errors: [String(error)] };
+    }
+  },
+);
+
+ipcMain.handle(
+  IPC.CATALOG_IMPORT,
+  (_event, installationPath: string, items: CatalogItemRef[], overwrite?: boolean) => {
+    const catalogPath = storeGet('catalogPath') as string | undefined;
+    if (!catalogPath) return { success: false, errors: ['No catalog path configured.'] };
+    try {
+      return importToCatalog(installationPath, items, catalogPath, overwrite ?? false);
+    } catch (error) {
+      return { success: false, errors: [String(error)] };
+    }
+  },
+);
+
+ipcMain.handle(IPC.CATALOG_DELETE, (_event, item: CatalogItemRef) => {
+  const catalogPath = storeGet('catalogPath') as string | undefined;
+  if (!catalogPath) return { success: false, error: 'No catalog path configured.' };
+  try {
+    return deleteCatalogItem(catalogPath, item);
+  } catch (error) {
+    return { success: false, error: String(error) };
+  }
+});
+
+ipcMain.handle(IPC.CATALOG_IMPORT_SMENT, (_event, smentPath: string) => {
+  const catalogPath = storeGet('catalogPath') as string | undefined;
+  if (!catalogPath) return { success: false, errors: ['No catalog path configured.'] };
+  try {
+    return importSmentToCatalog(catalogPath, smentPath);
+  } catch (error) {
+    return { success: false, errors: [String(error)] };
   }
 });
 

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -216,7 +216,7 @@ function loadRendererRoute(
 function createWindow(): void {
   const { height: workAreaHeight } = screen.getPrimaryDisplay().workAreaSize;
   const useShortScreenSizing = workAreaHeight < 720;
-  const initialHeight = useShortScreenSizing ? workAreaHeight : 900;
+  const initialHeight = useShortScreenSizing ? workAreaHeight : 1024;
   const minHeight = useShortScreenSizing ? Math.min(600, workAreaHeight) : 600;
 
   // Resolve the icon path: in packaged builds the icon is copied to
@@ -226,9 +226,9 @@ function createWindow(): void {
   const iconPath = getWindowIconPath();
 
   mainWindow = new BrowserWindow({
-    width: 1280,
+    width: 1460,
     height: initialHeight,
-    minWidth: 960,
+    minWidth: 1024,
     minHeight,
     resizable: true,
     thickFrame: true,
@@ -2509,18 +2509,18 @@ ipcMain.handle(IPC.MODS_IMPORT_MODPACK, async (_event, installationPath: string,
 // IPC surface serves both the Blueprints page (blueprintsCatalogPath) and the
 // Templates page (templatesCatalogPath).
 
-ipcMain.handle(IPC.CATALOG_LIST, (_event, catalogPath: string) => {
+ipcMain.handle(IPC.CATALOG_LIST, async (_event, catalogPath: string, invalidate?: boolean) => {
   if (!catalogPath) return { catalogPath: '', blueprints: [], exported: [], templates: [] };
   try {
-    return listCatalog(catalogPath);
+    return await listCatalog(catalogPath, invalidate);
   } catch (error) {
     return { catalogPath, blueprints: [], exported: [], templates: [], error: String(error) };
   }
 });
 
-ipcMain.handle(IPC.CATALOG_LIST_INSTALLATION, (_event, installationPath: string) => {
+ipcMain.handle(IPC.CATALOG_LIST_INSTALLATION, async (_event, installationPath: string, invalidate?: boolean) => {
   try {
-    return listInstallationBlueprints(installationPath);
+    return await listInstallationBlueprints(installationPath, invalidate);
   } catch (error) {
     return { catalogPath: installationPath, blueprints: [], exported: [], templates: [], error: String(error) };
   }
@@ -2570,10 +2570,10 @@ ipcMain.handle(IPC.CATALOG_IMPORT_SMENT, (_event, catalogPath: string, smentPath
 
 ipcMain.handle(
   IPC.CATALOG_SYNC_DIFF,
-  (_event, catalogPath: string, installationPath: string, kinds: Array<'blueprint' | 'exported' | 'template'>) => {
+  async (_event, catalogPath: string, installationPath: string, kinds: Array<'blueprint' | 'exported' | 'template'>) => {
     if (!catalogPath) return { items: [], newCount: 0, modifiedCount: 0, upToDateCount: 0 };
     try {
-      return computeSyncDiff(catalogPath, installationPath, kinds);
+      return await computeSyncDiff(catalogPath, installationPath, kinds);
     } catch (error) {
       return { items: [], newCount: 0, modifiedCount: 0, upToDateCount: 0, error: String(error) };
     }

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -804,8 +804,8 @@ const launcherApi = {
   /** Blueprint / Template Catalog APIs — all accept an explicit catalogPath so the
    *  same surface serves both the Blueprints page and the Templates page. */
   catalog: {
-    /** List all items in a catalog directory. */
-    list: (catalogPath: string): Promise<{
+    /** List all items in a catalog directory. Cached for 30s; pass invalidate=true to force refresh. */
+    list: (catalogPath: string, invalidate?: boolean): Promise<{
       catalogPath: string;
       blueprints: Array<{
         name: string;
@@ -820,10 +820,10 @@ const launcherApi = {
       exported: Array<{ fileName: string; sizeBytes: number; modifiedMs: number }>;
       templates: Array<{ fileName: string; sizeBytes: number; modifiedMs: number }>;
       error?: string;
-    }> => ipcRenderer.invoke(IPC.CATALOG_LIST, catalogPath),
+    }> => ipcRenderer.invoke(IPC.CATALOG_LIST, catalogPath, invalidate),
 
-    /** List blueprints/templates in a specific installation. */
-    listInstallation: (installationPath: string): Promise<{
+    /** List blueprints/templates in a specific installation. Cached for 30s; pass invalidate=true to force refresh. */
+    listInstallation: (installationPath: string, invalidate?: boolean): Promise<{
       catalogPath: string;
       blueprints: Array<{
         name: string;
@@ -838,7 +838,7 @@ const launcherApi = {
       exported: Array<{ fileName: string; sizeBytes: number; modifiedMs: number }>;
       templates: Array<{ fileName: string; sizeBytes: number; modifiedMs: number }>;
       error?: string;
-    }> => ipcRenderer.invoke(IPC.CATALOG_LIST_INSTALLATION, installationPath),
+    }> => ipcRenderer.invoke(IPC.CATALOG_LIST_INSTALLATION, installationPath, invalidate),
 
     /** Deploy items from a catalog directory to one or more installations. */
     deploy: (

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -801,6 +801,72 @@ const launcherApi = {
     }> => ipcRenderer.invoke(IPC.MODS_IMPORT_MODPACK, installationPath, manifestPath),
   },
 
+  /** Blueprint Catalog APIs */
+  catalog: {
+    /** List all items in the central blueprint catalog. */
+    list: (): Promise<{
+      catalogPath: string;
+      blueprints: Array<{
+        name: string;
+        type: string;
+        classification?: string;
+        boundingBox?: { min: [number, number, number]; max: [number, number, number] };
+        elementCount?: number;
+        sizeBytes: number;
+        modifiedMs: number;
+        dockedCount: number;
+      }>;
+      exported: Array<{ fileName: string; sizeBytes: number; modifiedMs: number }>;
+      templates: Array<{ fileName: string; sizeBytes: number; modifiedMs: number }>;
+      error?: string;
+    }> => ipcRenderer.invoke(IPC.CATALOG_LIST),
+
+    /** List blueprints/templates in a specific installation. */
+    listInstallation: (installationPath: string): Promise<{
+      catalogPath: string;
+      blueprints: Array<{
+        name: string;
+        type: string;
+        classification?: string;
+        boundingBox?: { min: [number, number, number]; max: [number, number, number] };
+        elementCount?: number;
+        sizeBytes: number;
+        modifiedMs: number;
+        dockedCount: number;
+      }>;
+      exported: Array<{ fileName: string; sizeBytes: number; modifiedMs: number }>;
+      templates: Array<{ fileName: string; sizeBytes: number; modifiedMs: number }>;
+      error?: string;
+    }> => ipcRenderer.invoke(IPC.CATALOG_LIST_INSTALLATION, installationPath),
+
+    /** Deploy items from catalog to one or more installations. */
+    deploy: (
+      items: Array<{ kind: string; name?: string; fileName?: string }>,
+      targetPaths: string[],
+      overwrite?: boolean,
+    ): Promise<{ success: boolean; copiedCount?: number; skippedCount?: number; errors?: string[] }> =>
+      ipcRenderer.invoke(IPC.CATALOG_DEPLOY, items, targetPaths, overwrite),
+
+    /** Import items from an installation into the catalog. */
+    import: (
+      installationPath: string,
+      items: Array<{ kind: string; name?: string; fileName?: string }>,
+      overwrite?: boolean,
+    ): Promise<{ success: boolean; copiedCount?: number; skippedCount?: number; errors?: string[] }> =>
+      ipcRenderer.invoke(IPC.CATALOG_IMPORT, installationPath, items, overwrite),
+
+    /** Delete an item from the catalog. */
+    delete: (
+      item: { kind: string; name?: string; fileName?: string },
+    ): Promise<{ success: boolean; error?: string }> =>
+      ipcRenderer.invoke(IPC.CATALOG_DELETE, item),
+
+    /** Import a .sment file into the catalog (extracts + copies). */
+    importSment: (smentPath: string): Promise<{
+      success: boolean; copiedCount?: number; errors?: string[];
+    }> => ipcRenderer.invoke(IPC.CATALOG_IMPORT_SMENT, smentPath),
+  },
+
   /** Legacy installation detection APIs */
   legacy: {
     /** Scan the current and sub-directories for legacy StarMade installations (containing StarMade.jar). */

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -801,10 +801,11 @@ const launcherApi = {
     }> => ipcRenderer.invoke(IPC.MODS_IMPORT_MODPACK, installationPath, manifestPath),
   },
 
-  /** Blueprint Catalog APIs */
+  /** Blueprint / Template Catalog APIs — all accept an explicit catalogPath so the
+   *  same surface serves both the Blueprints page and the Templates page. */
   catalog: {
-    /** List all items in the central blueprint catalog. */
-    list: (): Promise<{
+    /** List all items in a catalog directory. */
+    list: (catalogPath: string): Promise<{
       catalogPath: string;
       blueprints: Array<{
         name: string;
@@ -819,7 +820,7 @@ const launcherApi = {
       exported: Array<{ fileName: string; sizeBytes: number; modifiedMs: number }>;
       templates: Array<{ fileName: string; sizeBytes: number; modifiedMs: number }>;
       error?: string;
-    }> => ipcRenderer.invoke(IPC.CATALOG_LIST),
+    }> => ipcRenderer.invoke(IPC.CATALOG_LIST, catalogPath),
 
     /** List blueprints/templates in a specific installation. */
     listInstallation: (installationPath: string): Promise<{
@@ -839,32 +840,63 @@ const launcherApi = {
       error?: string;
     }> => ipcRenderer.invoke(IPC.CATALOG_LIST_INSTALLATION, installationPath),
 
-    /** Deploy items from catalog to one or more installations. */
+    /** Deploy items from a catalog directory to one or more installations. */
     deploy: (
+      catalogPath: string,
       items: Array<{ kind: string; name?: string; fileName?: string }>,
       targetPaths: string[],
       overwrite?: boolean,
     ): Promise<{ success: boolean; copiedCount?: number; skippedCount?: number; errors?: string[] }> =>
-      ipcRenderer.invoke(IPC.CATALOG_DEPLOY, items, targetPaths, overwrite),
+      ipcRenderer.invoke(IPC.CATALOG_DEPLOY, catalogPath, items, targetPaths, overwrite),
 
-    /** Import items from an installation into the catalog. */
+    /** Import items from an installation into a catalog directory. */
     import: (
+      catalogPath: string,
       installationPath: string,
       items: Array<{ kind: string; name?: string; fileName?: string }>,
       overwrite?: boolean,
     ): Promise<{ success: boolean; copiedCount?: number; skippedCount?: number; errors?: string[] }> =>
-      ipcRenderer.invoke(IPC.CATALOG_IMPORT, installationPath, items, overwrite),
+      ipcRenderer.invoke(IPC.CATALOG_IMPORT, catalogPath, installationPath, items, overwrite),
 
-    /** Delete an item from the catalog. */
+    /** Delete an item from a catalog directory. */
     delete: (
+      catalogPath: string,
       item: { kind: string; name?: string; fileName?: string },
     ): Promise<{ success: boolean; error?: string }> =>
-      ipcRenderer.invoke(IPC.CATALOG_DELETE, item),
+      ipcRenderer.invoke(IPC.CATALOG_DELETE, catalogPath, item),
 
-    /** Import a .sment file into the catalog (extracts + copies). */
-    importSment: (smentPath: string): Promise<{
+    /** Import a .sment file into a catalog directory (extracts + copies). */
+    importSment: (catalogPath: string, smentPath: string): Promise<{
       success: boolean; copiedCount?: number; errors?: string[];
-    }> => ipcRenderer.invoke(IPC.CATALOG_IMPORT_SMENT, smentPath),
+    }> => ipcRenderer.invoke(IPC.CATALOG_IMPORT_SMENT, catalogPath, smentPath),
+
+    /** Compute sync diff between catalog and installation. */
+    syncDiff: (
+      catalogPath: string,
+      installationPath: string,
+      kinds: Array<'blueprint' | 'exported' | 'template'>,
+    ): Promise<{
+      items: Array<{
+        ref: { kind: string; name?: string; fileName?: string };
+        label: string;
+        status: 'new' | 'modified' | 'up-to-date';
+        catalogModifiedMs: number;
+        installModifiedMs: number;
+      }>;
+      newCount: number;
+      modifiedCount: number;
+      upToDateCount: number;
+      error?: string;
+    }> => ipcRenderer.invoke(IPC.CATALOG_SYNC_DIFF, catalogPath, installationPath, kinds),
+
+    /** Apply sync: deploy items from catalog to installation. */
+    syncApply: (
+      catalogPath: string,
+      items: Array<{ kind: string; name?: string; fileName?: string }>,
+      targetPath: string,
+      overwrite?: boolean,
+    ): Promise<{ success: boolean; copiedCount?: number; skippedCount?: number; errors?: string[] }> =>
+      ipcRenderer.invoke(IPC.CATALOG_SYNC_APPLY, catalogPath, items, targetPath, overwrite),
   },
 
   /** Legacy installation detection APIs */

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "starmade-launcher",
   "private": true,
-  "version": "4.1.13",
+  "version": "4.2.0",
   "description": "StarMade Launcher",
   "author": "Schine GmbH & StarMade Contributors",
   "type": "module",

--- a/types/electron.d.ts
+++ b/types/electron.d.ts
@@ -478,6 +478,64 @@ declare global {
         }>;
       };
 
+      /** Blueprint Catalog APIs */
+      catalog: {
+        /** List all items in the central blueprint catalog. */
+        list: () => Promise<{
+          catalogPath: string;
+          blueprints: Array<{
+            name: string;
+            type: string;
+            classification?: string;
+            boundingBox?: { min: [number, number, number]; max: [number, number, number] };
+            elementCount?: number;
+            sizeBytes: number;
+            modifiedMs: number;
+            dockedCount: number;
+          }>;
+          exported: Array<{ fileName: string; sizeBytes: number; modifiedMs: number }>;
+          templates: Array<{ fileName: string; sizeBytes: number; modifiedMs: number }>;
+          error?: string;
+        }>;
+        /** List blueprints/templates in a specific installation. */
+        listInstallation: (installationPath: string) => Promise<{
+          catalogPath: string;
+          blueprints: Array<{
+            name: string;
+            type: string;
+            classification?: string;
+            boundingBox?: { min: [number, number, number]; max: [number, number, number] };
+            elementCount?: number;
+            sizeBytes: number;
+            modifiedMs: number;
+            dockedCount: number;
+          }>;
+          exported: Array<{ fileName: string; sizeBytes: number; modifiedMs: number }>;
+          templates: Array<{ fileName: string; sizeBytes: number; modifiedMs: number }>;
+          error?: string;
+        }>;
+        /** Deploy items from catalog to one or more installations. */
+        deploy: (
+          items: Array<{ kind: string; name?: string; fileName?: string }>,
+          targetPaths: string[],
+          overwrite?: boolean,
+        ) => Promise<{ success: boolean; copiedCount?: number; skippedCount?: number; errors?: string[] }>;
+        /** Import items from an installation into the catalog. */
+        import: (
+          installationPath: string,
+          items: Array<{ kind: string; name?: string; fileName?: string }>,
+          overwrite?: boolean,
+        ) => Promise<{ success: boolean; copiedCount?: number; skippedCount?: number; errors?: string[] }>;
+        /** Delete an item from the catalog. */
+        delete: (
+          item: { kind: string; name?: string; fileName?: string },
+        ) => Promise<{ success: boolean; error?: string }>;
+        /** Import a .sment file into the catalog (extracts + copies). */
+        importSment: (smentPath: string) => Promise<{
+          success: boolean; copiedCount?: number; errors?: string[];
+        }>;
+      };
+
       /** Icon image APIs */
       icons: {
         /** List available icon image paths (file:// URLs). */

--- a/types/electron.d.ts
+++ b/types/electron.d.ts
@@ -478,10 +478,9 @@ declare global {
         }>;
       };
 
-      /** Blueprint Catalog APIs */
+      /** Blueprint / Template Catalog APIs — all accept an explicit catalogPath. */
       catalog: {
-        /** List all items in the central blueprint catalog. */
-        list: () => Promise<{
+        list: (catalogPath: string) => Promise<{
           catalogPath: string;
           blueprints: Array<{
             name: string;
@@ -497,7 +496,6 @@ declare global {
           templates: Array<{ fileName: string; sizeBytes: number; modifiedMs: number }>;
           error?: string;
         }>;
-        /** List blueprints/templates in a specific installation. */
         listInstallation: (installationPath: string) => Promise<{
           catalogPath: string;
           blueprints: Array<{
@@ -514,26 +512,15 @@ declare global {
           templates: Array<{ fileName: string; sizeBytes: number; modifiedMs: number }>;
           error?: string;
         }>;
-        /** Deploy items from catalog to one or more installations. */
-        deploy: (
-          items: Array<{ kind: string; name?: string; fileName?: string }>,
-          targetPaths: string[],
-          overwrite?: boolean,
-        ) => Promise<{ success: boolean; copiedCount?: number; skippedCount?: number; errors?: string[] }>;
-        /** Import items from an installation into the catalog. */
-        import: (
-          installationPath: string,
-          items: Array<{ kind: string; name?: string; fileName?: string }>,
-          overwrite?: boolean,
-        ) => Promise<{ success: boolean; copiedCount?: number; skippedCount?: number; errors?: string[] }>;
-        /** Delete an item from the catalog. */
-        delete: (
-          item: { kind: string; name?: string; fileName?: string },
-        ) => Promise<{ success: boolean; error?: string }>;
-        /** Import a .sment file into the catalog (extracts + copies). */
-        importSment: (smentPath: string) => Promise<{
-          success: boolean; copiedCount?: number; errors?: string[];
+        deploy: (catalogPath: string, items: Array<{ kind: string; name?: string; fileName?: string }>, targetPaths: string[], overwrite?: boolean) => Promise<{ success: boolean; copiedCount?: number; skippedCount?: number; errors?: string[] }>;
+        import: (catalogPath: string, installationPath: string, items: Array<{ kind: string; name?: string; fileName?: string }>, overwrite?: boolean) => Promise<{ success: boolean; copiedCount?: number; skippedCount?: number; errors?: string[] }>;
+        delete: (catalogPath: string, item: { kind: string; name?: string; fileName?: string }) => Promise<{ success: boolean; error?: string }>;
+        importSment: (catalogPath: string, smentPath: string) => Promise<{ success: boolean; copiedCount?: number; errors?: string[] }>;
+        syncDiff: (catalogPath: string, installationPath: string, kinds: Array<'blueprint' | 'exported' | 'template'>) => Promise<{
+          items: Array<{ ref: { kind: string; name?: string; fileName?: string }; label: string; status: 'new' | 'modified' | 'up-to-date'; catalogModifiedMs: number; installModifiedMs: number }>;
+          newCount: number; modifiedCount: number; upToDateCount: number; error?: string;
         }>;
+        syncApply: (catalogPath: string, items: Array<{ kind: string; name?: string; fileName?: string }>, targetPath: string, overwrite?: boolean) => Promise<{ success: boolean; copiedCount?: number; skippedCount?: number; errors?: string[] }>;
       };
 
       /** Icon image APIs */

--- a/types/electron.d.ts
+++ b/types/electron.d.ts
@@ -480,7 +480,7 @@ declare global {
 
       /** Blueprint / Template Catalog APIs — all accept an explicit catalogPath. */
       catalog: {
-        list: (catalogPath: string) => Promise<{
+        list: (catalogPath: string, invalidate?: boolean) => Promise<{
           catalogPath: string;
           blueprints: Array<{
             name: string;
@@ -496,7 +496,7 @@ declare global {
           templates: Array<{ fileName: string; sizeBytes: number; modifiedMs: number }>;
           error?: string;
         }>;
-        listInstallation: (installationPath: string) => Promise<{
+        listInstallation: (installationPath: string, invalidate?: boolean) => Promise<{
           catalogPath: string;
           blueprints: Array<{
             name: string;

--- a/types/index.ts
+++ b/types/index.ts
@@ -282,7 +282,7 @@ export interface LauncherSettingsData {
   closeBehavior: LauncherCloseBehavior;
 }
 
-export type Page = 'Play' | 'Installations' | 'News' | 'Screenshots' | 'Mods' | 'Catalog' | 'Settings' | 'ServerPanel';
+export type Page = 'Play' | 'Installations' | 'News' | 'Screenshots' | 'Mods' | 'Blueprints' | 'Templates' | 'Settings' | 'ServerPanel';
 export type SettingsSection = 'launcher' | 'accounts' | 'about' | 'defaults';
 export type InstallationsTab = 'installations' | 'servers';
 

--- a/types/index.ts
+++ b/types/index.ts
@@ -228,6 +228,52 @@ export type ServerLogLevel = 'INFO' | 'WARNING' | 'ERROR' | 'FATAL' | 'DEBUG' | 
 
 export type LauncherCloseBehavior = 'Close launcher' | 'Hide launcher' | 'Keep the launcher open';
 
+// ─── Blueprint Catalog Types ──────────────────────────────────────────────────
+
+export type BlueprintEntityType = 'SHIP' | 'SPACE_STATION' | 'SHOP' | 'ASTEROID' | 'PLANET' | 'MANAGED_ASTEROID' | 'UNKNOWN';
+
+export interface BlueprintMeta {
+  name: string;
+  type: BlueprintEntityType;
+  classification?: string;
+  boundingBox?: { min: [number, number, number]; max: [number, number, number] };
+  elementCount?: number;
+  sizeBytes: number;
+  modifiedMs: number;
+  dockedCount: number;
+}
+
+export interface ExportedBlueprintMeta {
+  fileName: string;
+  sizeBytes: number;
+  modifiedMs: number;
+}
+
+export interface TemplateMeta {
+  fileName: string;
+  sizeBytes: number;
+  modifiedMs: number;
+}
+
+export interface CatalogListing {
+  catalogPath: string;
+  blueprints: BlueprintMeta[];
+  exported: ExportedBlueprintMeta[];
+  templates: TemplateMeta[];
+}
+
+export type CatalogItemRef =
+  | { kind: 'blueprint'; name: string }
+  | { kind: 'exported'; fileName: string }
+  | { kind: 'template'; fileName: string };
+
+export interface CatalogCopyResult {
+  success: boolean;
+  copiedCount?: number;
+  skippedCount?: number;
+  errors?: string[];
+}
+
 export interface LauncherSettingsData {
   checkForUpdates: boolean;
   useBetaChannel: boolean;
@@ -236,7 +282,7 @@ export interface LauncherSettingsData {
   closeBehavior: LauncherCloseBehavior;
 }
 
-export type Page = 'Play' | 'Installations' | 'News' | 'Screenshots' | 'Mods' | 'Settings' | 'ServerPanel';
+export type Page = 'Play' | 'Installations' | 'News' | 'Screenshots' | 'Mods' | 'Blueprints' | 'Settings' | 'ServerPanel';
 export type SettingsSection = 'launcher' | 'accounts' | 'about' | 'defaults';
 export type InstallationsTab = 'installations' | 'servers';
 

--- a/types/index.ts
+++ b/types/index.ts
@@ -282,7 +282,7 @@ export interface LauncherSettingsData {
   closeBehavior: LauncherCloseBehavior;
 }
 
-export type Page = 'Play' | 'Installations' | 'News' | 'Screenshots' | 'Mods' | 'Blueprints' | 'Settings' | 'ServerPanel';
+export type Page = 'Play' | 'Installations' | 'News' | 'Screenshots' | 'Mods' | 'Catalog' | 'Settings' | 'ServerPanel';
 export type SettingsSection = 'launcher' | 'accounts' | 'about' | 'defaults';
 export type InstallationsTab = 'installations' | 'servers';
 


### PR DESCRIPTION
This pull request adds new support for managing Blueprints and Templates within the application. It introduces new pages for Blueprints and Templates, updates navigation, and expands the Settings page to allow users to configure catalog directories and auto-sync options for these resources.

**Blueprints & Templates Management:**

* Added new pages: `Blueprints` and `Templates`, with corresponding navigation entries and routing logic in `App.tsx`. [[1]](diffhunk://#diff-a369d17a5dcc6a08663afe8ec644ed0ebc2624f39b704924078c01fd52c58fa3R7-R8) [[2]](diffhunk://#diff-a369d17a5dcc6a08663afe8ec644ed0ebc2624f39b704924078c01fd52c58fa3R349-R352) [[3]](diffhunk://#diff-fcb662a9307cafb03cb4a70f6d2ffead1ab24da3d4f0911dc2fae2da834b1ef1L232-R232)

**Settings Page Enhancements:**

* Introduced new settings fields in `LauncherSettings.tsx` for selecting and displaying Blueprints and Templates catalog directories, including UI to browse and open these paths. [[1]](diffhunk://#diff-12a7a732395bb2137b123e8c6a6b44c6b4b3d1bdb84be145f52900981317604fR98-R103) [[2]](diffhunk://#diff-12a7a732395bb2137b123e8c6a6b44c6b4b3d1bdb84be145f52900981317604fR747-R846)
* Added auto-sync toggle options for Blueprints and Templates, and logic to persist these settings using the application's store. [[1]](diffhunk://#diff-12a7a732395bb2137b123e8c6a6b44c6b4b3d1bdb84be145f52900981317604fR98-R103) [[2]](diffhunk://#diff-12a7a732395bb2137b123e8c6a6b44c6b4b3d1bdb84be145f52900981317604fR144-R157) [[3]](diffhunk://#diff-12a7a732395bb2137b123e8c6a6b44c6b4b3d1bdb84be145f52900981317604fR747-R846)
* On settings load, retrieves and initializes the catalog paths and auto-sync settings from persistent storage.

These changes collectively provide users with centralized management and synchronization options for Blueprints and Templates across installations.